### PR TITLE
Add support for Hangfire 1.3.0

### DIFF
--- a/nuspecs/HangFire.Mongo.nuspec
+++ b/nuspecs/HangFire.Mongo.nuspec
@@ -19,12 +19,8 @@
 * Initial public release            
         </releaseNotes>
         <dependencies>
-            <dependency id="HangFire.Core" version="1.2.2" />
-            <dependency id="Owin" version="1.0" />
+            <dependency id="HangFire.Core" version="1.3.0" />
             <dependency id="mongocsharpdriver" version="1.9.2" />
-            <dependency id="Newtonsoft.Json" version="6.0.6" />
-            <dependency id="Common.Logging" version="2.2.0" />
-            <dependency id="Common.Logging.Core" version="2.2.0" />
         </dependencies>
     </metadata>
     <files>

--- a/src/Hangfire.Mongo/DistributedLock/MongoDistributedLock.cs
+++ b/src/Hangfire.Mongo/DistributedLock/MongoDistributedLock.cs
@@ -1,4 +1,4 @@
-using Common.Logging;
+using Hangfire.Logging;
 using Hangfire.Mongo.Database;
 using Hangfire.Mongo.Dto;
 using Hangfire.Mongo.MongoUtils;
@@ -11,7 +11,7 @@ namespace Hangfire.Mongo.DistributedLock
 {
 	public class MongoDistributedLock : IDisposable
 	{
-		private static readonly ILog Logger = LogManager.GetLogger(typeof(MongoDistributedLock));
+	    private static readonly ILog Logger = LogProvider.GetCurrentClassLogger();
 
 		private readonly HangfireDbContext _database;
 

--- a/src/Hangfire.Mongo/ExpirationManager.cs
+++ b/src/Hangfire.Mongo/ExpirationManager.cs
@@ -1,10 +1,9 @@
-﻿using Common.Logging;
+﻿using Hangfire.Logging;
 using Hangfire.Mongo.Database;
 using Hangfire.Mongo.MongoUtils;
 using Hangfire.Server;
 using System;
 using System.Threading;
-using MongoDB.Bson;
 using MongoDB.Driver;
 using MongoDB.Driver.Builders;
 
@@ -12,7 +11,7 @@ namespace Hangfire.Mongo
 {
 	public class ExpirationManager : IServerComponent
 	{
-		private static readonly ILog Logger = LogManager.GetLogger(typeof(ExpirationManager));
+	    private static readonly ILog Logger = LogProvider.GetCurrentClassLogger();
 
 		private readonly MongoStorage _storage;
 		private readonly TimeSpan _checkInterval;

--- a/src/Hangfire.Mongo/Hangfire.Mongo.csproj
+++ b/src/Hangfire.Mongo/Hangfire.Mongo.csproj
@@ -35,15 +35,9 @@
     <DocumentationFile>bin\Release\Hangfire.Mongo.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Common.Logging, Version=2.2.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Common.Logging.2.2.0\lib\net40\Common.Logging.dll</HintPath>
-    </Reference>
-    <Reference Include="Common.Logging.Core, Version=2.2.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Common.Logging.Core.2.2.0\lib\net40\Common.Logging.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Hangfire.Core, Version=1.2.2.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Hangfire.Core, Version=1.3.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\HangFire.Core.1.2.2\lib\net45\Hangfire.Core.dll</HintPath>
+      <HintPath>..\..\packages\HangFire.Core.1.3.0\lib\net45\Hangfire.Core.dll</HintPath>
     </Reference>
     <Reference Include="MongoDB.Bson">
       <HintPath>..\..\packages\mongocsharpdriver.1.9.2\lib\net35\MongoDB.Bson.dll</HintPath>
@@ -109,7 +103,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Hangfire.Mongo/MongoStorage.cs
+++ b/src/Hangfire.Mongo/MongoStorage.cs
@@ -1,4 +1,4 @@
-﻿using Common.Logging;
+﻿using Hangfire.Logging;
 using Hangfire.Mongo.Database;
 using Hangfire.Mongo.PersistentJobQueue;
 using Hangfire.Mongo.PersistentJobQueue.Mongo;

--- a/src/Hangfire.Mongo/packages.config
+++ b/src/Hangfire.Mongo/packages.config
@@ -1,8 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Common.Logging" version="2.2.0" targetFramework="net45" />
-  <package id="Common.Logging.Core" version="2.2.0" targetFramework="net45" />
-  <package id="HangFire.Core" version="1.2.2" targetFramework="net451" />
+  <package id="HangFire.Core" version="1.3.0" targetFramework="net451" />
   <package id="mongocsharpdriver" version="1.9.2" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.6" targetFramework="net451" />
   <package id="Owin" version="1.0" targetFramework="net451" />

--- a/tests/Hangfire.Mongo.Tests/Hangfire.Mongo.Tests.csproj
+++ b/tests/Hangfire.Mongo.Tests/Hangfire.Mongo.Tests.csproj
@@ -32,17 +32,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Common.Logging, Version=2.0.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+    <Reference Include="Hangfire.Core, Version=1.3.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Common.Logging.2.2.0\lib\net40\Common.Logging.dll</HintPath>
-    </Reference>
-    <Reference Include="Common.Logging.Core, Version=2.2.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Common.Logging.Core.2.2.0\lib\net40\Common.Logging.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Hangfire.Core, Version=1.2.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Hangfire.Core.1.2.2\lib\net45\Hangfire.Core.dll</HintPath>
+      <HintPath>..\..\packages\Hangfire.Core.1.3.0\lib\net45\Hangfire.Core.dll</HintPath>
     </Reference>
     <Reference Include="MongoDB.Bson, Version=1.9.2.235, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -96,6 +88,9 @@
       <Project>{1fe9c86e-db7a-4c1b-b73a-42b993d68688}</Project>
       <Name>Hangfire.Mongo</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/tests/Hangfire.Mongo.Tests/packages.config
+++ b/tests/Hangfire.Mongo.Tests/packages.config
@@ -1,8 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-	<package id="Common.Logging" version="2.2.0" targetFramework="net45" />
-	<package id="Common.Logging.Core" version="2.2.0" targetFramework="net45" />
-	<package id="Hangfire.Core" version="1.2.2" targetFramework="net451" />
+  <package id="Hangfire.Core" version="1.3.0" targetFramework="net451" />
   <package id="mongocsharpdriver" version="1.9.2" targetFramework="net451" />
   <package id="Moq" version="4.2.1409.1722" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="5.0.1" targetFramework="net451" />


### PR DESCRIPTION
This PR adds support for [Hangfire 1.3.0](https://github.com/HangfireIO/Hangfire/releases/tag/v1.3.0) version (no more `Common.Logging`).
- Update `Hangfire.Core` reference to version 1.3.0
- Remove `Common.Logging`, `Owin` and `Newtonsoft.Json` dependencies from nuspec.
