### PR TITLE
Moving index assignment after filtering to ensure proper paging

### DIFF
--- a/src/Hangfire.Mongo/MongoMonitoringApi.cs
+++ b/src/Hangfire.Mongo/MongoMonitoringApi.cs
@@ -456,12 +456,12 @@ namespace Hangfire.Mongo
                 .ToListAsync())
                 .ToArray()
                 .Reverse()
-                .Select((data, i) => new { Index = i + 1, Data = data })
                 .Where(job =>
                 {
-                    var state = AsyncHelper.RunSync(() => connection.State.Find(Builders<StateDto>.Filter.Eq(_ => _.Id, job.Data.StateId)).FirstOrDefaultAsync());
+                    var state = AsyncHelper.RunSync(() => connection.State.Find(Builders<StateDto>.Filter.Eq(_ => _.Id, job.StateId)).FirstOrDefaultAsync());
                     return (state != null) && (state.Name == stateName);
                 })
+                .Select((data, i) => new { Index = i + 1, Data = data })
                 .Where(_ => (_.Index >= start) && (_.Index <= end))
                 .Select(job =>
                 {


### PR DESCRIPTION
I had about 50 total jobs and 1 failed. When I went to the Failed page in Dashboard, it said 1 item, but I had to increase the page size to show that 1 job. Swapping the indexing to after the filter by job state fixes the issue.