### PR TITLE
Moving skip, limit and projection to be done Mongo server side

### DIFF
--- a/src/Hangfire.Mongo.Tests/Hangfire.Mongo.Tests.csproj
+++ b/src/Hangfire.Mongo.Tests/Hangfire.Mongo.Tests.csproj
@@ -87,6 +87,7 @@
     <Compile Include="MongoDistributedLockFacts.cs" />
     <Compile Include="MongoFetchedJobFacts.cs" />
     <Compile Include="MongoJobQueueFacts.cs" />
+    <Compile Include="MongoMonitoringApiFacts.cs" />
     <Compile Include="MongoStorageFacts.cs" />
     <Compile Include="MongoStorageOptionsFacts.cs" />
     <Compile Include="MongoWriteOnlyTransactionFacts.cs" />

--- a/src/Hangfire.Mongo.Tests/MongoMonitoringApiFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoMonitoringApiFacts.cs
@@ -1,0 +1,271 @@
+﻿using System;
+using System.Collections.Generic;
+using Hangfire.Common;
+using Hangfire.Mongo.Database;
+using Hangfire.Mongo.Dto;
+using Hangfire.Mongo.Helpers;
+using Hangfire.Mongo.MongoUtils;
+using Hangfire.Mongo.PersistentJobQueue;
+using Hangfire.Mongo.Tests.Utils;
+using Hangfire.States;
+using Hangfire.Storage;
+using Moq;
+using Xunit;
+
+namespace Hangfire.Mongo.Tests
+{
+    [Collection("Database")]
+    public class MongoMonitoringApiFacts
+    {
+        private const string DefaultQueue = "default";
+        private const string FetchedStateName = "Fetched";
+        private const int From = 0;
+        private const int PerPage = 5;
+        private readonly Mock<IPersistentJobQueue> _queue;
+        private readonly Mock<IPersistentJobQueueProvider> _provider;
+        private readonly Mock<IPersistentJobQueueMonitoringApi> _persistentJobQueueMonitoringApi;
+        private readonly PersistentJobQueueProviderCollection _providers;
+
+        public MongoMonitoringApiFacts()
+        {
+            _queue = new Mock<IPersistentJobQueue>();
+            _persistentJobQueueMonitoringApi = new Mock<IPersistentJobQueueMonitoringApi>();
+
+            _provider = new Mock<IPersistentJobQueueProvider>();
+            _provider.Setup(x => x.GetJobQueue(It.IsNotNull<HangfireDbContext>())).Returns(_queue.Object);
+            _provider.Setup(x => x.GetJobQueueMonitoringApi(It.IsNotNull<HangfireDbContext>()))
+                .Returns(_persistentJobQueueMonitoringApi.Object);
+
+            _providers = new PersistentJobQueueProviderCollection(_provider.Object);
+        }
+
+        [Fact, CleanDatabase]
+        public void JobDetails_ReturnsNull_WhenThereIsNoSuchJob()
+        {
+            UseMonitoringApi((database, monitoringApi) =>
+            {
+                var result = monitoringApi.JobDetails("547527");
+                Assert.Null(result);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void JobDetails_ReturnsResult_WhenJobExists()
+        {
+            UseMonitoringApi((database, monitoringApi) =>
+            {
+                var job1 = CreateJobInState(database, 1, EnqueuedState.StateName);
+
+                var result = monitoringApi.JobDetails(job1.Id.ToString());
+
+                Assert.NotNull(result);
+                Assert.NotNull(result.Job);
+                Assert.Equal("Arguments", result.Job.Arguments[0]);
+                Assert.True(database.GetServerTimeUtc().AddMinutes(-1) < result.CreatedAt);
+                Assert.True(result.CreatedAt < DateTime.UtcNow.AddMinutes(1));
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void EnqueuedJobs_ReturnsEmpty_WhenThereIsNoJobs()
+        {
+            UseMonitoringApi((database, monitoringApi) =>
+            {
+                var jobIds = new List<int>();
+
+                this._persistentJobQueueMonitoringApi.Setup(x => x
+                    .GetEnqueuedJobIds(DefaultQueue, From, PerPage))
+                    .Returns(jobIds);
+
+                var resultList = monitoringApi.EnqueuedJobs(DefaultQueue, From, PerPage);
+
+                Assert.Empty(resultList);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void EnqueuedJobs_ReturnsSingleJob_WhenOneJobExistsThatIsNotFetched()
+        {
+            UseMonitoringApi((database, monitoringApi) =>
+            {
+                var unfetchedJob = CreateJobInState(database, 1, EnqueuedState.StateName);
+
+                var jobIds = new List<int> { unfetchedJob.Id };
+                this._persistentJobQueueMonitoringApi.Setup(x => x
+                    .GetEnqueuedJobIds(DefaultQueue, From, PerPage))
+                    .Returns(jobIds);
+
+                var resultList = monitoringApi.EnqueuedJobs(DefaultQueue, From, PerPage);
+
+                Assert.Equal(1, resultList.Count);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void EnqueuedJobs_ReturnsEmpty_WhenOneJobExistsThatIsFetched()
+        {
+            UseMonitoringApi((database, monitoringApi) =>
+            {
+                var fetchedJob = CreateJobInState(database, 1, FetchedStateName);
+
+                var jobIds = new List<int> { fetchedJob.Id };
+                this._persistentJobQueueMonitoringApi.Setup(x => x
+                    .GetEnqueuedJobIds(DefaultQueue, From, PerPage))
+                    .Returns(jobIds);
+
+                var resultList = monitoringApi.EnqueuedJobs(DefaultQueue, From, PerPage);
+
+                Assert.Empty(resultList);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void EnqueuedJobs_ReturnsUnfetchedJobsOnly_WhenMultipleJobsExistsInFetchedAndUnfetchedStates()
+        {
+            UseMonitoringApi((database, monitoringApi) =>
+            {
+                var unfetchedJob = CreateJobInState(database, 1, EnqueuedState.StateName);
+                var unfetchedJob2 = CreateJobInState(database, 2, EnqueuedState.StateName);
+                var fetchedJob = CreateJobInState(database, 3, FetchedStateName);
+
+                var jobIds = new List<int> { unfetchedJob.Id, unfetchedJob2.Id, fetchedJob.Id };
+                this._persistentJobQueueMonitoringApi.Setup(x => x
+                    .GetEnqueuedJobIds(DefaultQueue, From, PerPage))
+                    .Returns(jobIds);
+
+                var resultList = monitoringApi.EnqueuedJobs(DefaultQueue, From, PerPage);
+
+                Assert.Equal(2, resultList.Count);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void FetchedJobs_ReturnsEmpty_WhenThereIsNoJobs()
+        {
+            UseMonitoringApi((database, monitoringApi) =>
+            {
+                var jobIds = new List<int>();
+
+                this._persistentJobQueueMonitoringApi.Setup(x => x
+                    .GetFetchedJobIds(DefaultQueue, From, PerPage))
+                    .Returns(jobIds);
+
+                var resultList = monitoringApi.FetchedJobs(DefaultQueue, From, PerPage);
+
+                Assert.Empty(resultList);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void FetchedJobs_ReturnsSingleJob_WhenOneJobExistsThatIsFetched()
+        {
+            UseMonitoringApi((database, monitoringApi) =>
+            {
+                var fetchedJob = CreateJobInState(database, 1, FetchedStateName);
+
+                var jobIds = new List<int> { fetchedJob.Id };
+                this._persistentJobQueueMonitoringApi.Setup(x => x
+                    .GetFetchedJobIds(DefaultQueue, From, PerPage))
+                    .Returns(jobIds);
+
+                var resultList = monitoringApi.FetchedJobs(DefaultQueue, From, PerPage);
+
+                Assert.Equal(1, resultList.Count);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void FetchedJobs_ReturnsEmpty_WhenOneJobExistsThatIsNotFetched()
+        {
+            UseMonitoringApi((database, monitoringApi) =>
+            {
+                var unfetchedJob = CreateJobInState(database, 1, EnqueuedState.StateName);
+
+                var jobIds = new List<int> { unfetchedJob.Id };
+                this._persistentJobQueueMonitoringApi.Setup(x => x
+                    .GetFetchedJobIds(DefaultQueue, From, PerPage))
+                    .Returns(jobIds);
+
+                var resultList = monitoringApi.FetchedJobs(DefaultQueue, From, PerPage);
+
+                Assert.Empty(resultList);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void FetchedJobs_ReturnsFetchedJobsOnly_WhenMultipleJobsExistsInFetchedAndUnfetchedStates()
+        {
+            UseMonitoringApi((database, monitoringApi) =>
+            {
+                var fetchedJob = CreateJobInState(database, 1, FetchedStateName);
+                var fetchedJob2 = CreateJobInState(database, 2, FetchedStateName);
+                var unfetchedJob = CreateJobInState(database, 3, EnqueuedState.StateName);
+
+                var jobIds = new List<int> { fetchedJob.Id, fetchedJob2.Id, unfetchedJob.Id };
+                this._persistentJobQueueMonitoringApi.Setup(x => x
+                    .GetFetchedJobIds(DefaultQueue, From, PerPage))
+                    .Returns(jobIds);
+
+                var resultList = monitoringApi.FetchedJobs(DefaultQueue, From, PerPage);
+
+                Assert.Equal(2, resultList.Count);
+            });
+        }
+
+        public static void SampleMethod(string arg)
+        {
+        }
+
+        private void UseMonitoringApi(Action<HangfireDbContext, MongoMonitoringApi> action)
+        {
+            using (var database = ConnectionUtils.CreateConnection())
+            {
+                var connection = new MongoMonitoringApi(database, _providers);
+                action(database, connection);
+            }
+        }
+
+        private JobDto CreateJobInState(HangfireDbContext database, int jobId, string stateName)
+        {
+            var job = Job.FromExpression(() => SampleMethod("wrong"));
+
+            var jobState = new StateDto
+            {
+                CreatedAt = database.GetServerTimeUtc(),
+                Data = stateName == EnqueuedState.StateName
+                           ? string.Format(" {{ 'EnqueuedAt': '{0}' }}", database.GetServerTimeUtc())
+                           : "{}",
+                JobId = jobId
+            };
+            AsyncHelper.RunSync(() => database.State.InsertOneAsync(jobState));
+
+            var jobDto = new JobDto
+            {
+                Id = jobId,
+                InvocationData = JobHelper.ToJson(InvocationData.Serialize(job)),
+                Arguments = "['Arguments']",
+                StateName = stateName,
+                CreatedAt = database.GetServerTimeUtc(),
+                StateId = jobState.Id
+            };
+            AsyncHelper.RunSync(() => database.Job.InsertOneAsync(jobDto));
+
+            var jobQueueDto = new JobQueueDto
+            {
+                FetchedAt = null,
+                Id = jobId * 10,
+                JobId = jobId,
+                Queue = DefaultQueue
+            };
+
+            if (stateName == FetchedStateName)
+            {
+                jobQueueDto.FetchedAt = database.GetServerTimeUtc();
+            }
+
+            AsyncHelper.RunSync(() => database.JobQueue.InsertOneAsync(jobQueueDto));
+
+            return jobDto;
+        }
+    }
+}

--- a/src/Hangfire.Mongo/Helpers/AsyncHelper.cs
+++ b/src/Hangfire.Mongo/Helpers/AsyncHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Hangfire.Mongo.Helpers
@@ -8,12 +9,12 @@ namespace Hangfire.Mongo.Helpers
     {
         public static TResult RunSync<TResult>(Func<Task<TResult>> func)
         {
-            return Task.Run(func).GetAwaiter().GetResult();
+            return Task.Run(func, CancellationToken.None).GetAwaiter().GetResult();
         }
 
         public static void RunSync(Func<Task> func)
         {
-            Task.Run(func).GetAwaiter().GetResult();
+            Task.Run(func, CancellationToken.None).GetAwaiter().GetResult();
         }
     }
 #pragma warning restore 1591

--- a/src/Hangfire.Mongo/Helpers/AsyncHelper.cs
+++ b/src/Hangfire.Mongo/Helpers/AsyncHelper.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Hangfire.Mongo.Helpers
@@ -7,16 +6,14 @@ namespace Hangfire.Mongo.Helpers
 #pragma warning disable 1591
     public static class AsyncHelper
     {
-        private static readonly TaskFactory MyTaskFactory = new TaskFactory(CancellationToken.None, TaskCreationOptions.None, TaskContinuationOptions.None, TaskScheduler.Default);
-
         public static TResult RunSync<TResult>(Func<Task<TResult>> func)
         {
-            return MyTaskFactory.StartNew(func).Unwrap().GetAwaiter().GetResult();
+            return Task.Run(func).GetAwaiter().GetResult();
         }
 
         public static void RunSync(Func<Task> func)
         {
-            MyTaskFactory.StartNew(func).Unwrap().GetAwaiter().GetResult();
+            Task.Run(func).GetAwaiter().GetResult();
         }
     }
 #pragma warning restore 1591

--- a/src/Hangfire.Mongo/MongoConnection.cs
+++ b/src/Hangfire.Mongo/MongoConnection.cs
@@ -263,8 +263,10 @@ namespace Hangfire.Mongo
         {
             if (key == null) throw new ArgumentNullException("key");
 
-            IEnumerable<string> result = AsyncHelper.RunSync(() => _database.Set.Find(Builders<SetDto>.Filter.Eq(_ => _.Key, key)).ToListAsync())
-                .Select(x => x.Value);
+            IEnumerable<string> result = AsyncHelper.RunSync(() => _database.Set
+                .Find(Builders<SetDto>.Filter.Eq(_ => _.Key, key))
+                .Project(dto => dto.Value)
+                .ToListAsync());
 
             return new HashSet<string>(result);
         }
@@ -277,14 +279,13 @@ namespace Hangfire.Mongo
             if (toScore < fromScore)
                 throw new ArgumentException("The `toScore` value must be higher or equal to the `fromScore` value.");
 
-            SetDto set = AsyncHelper.RunSync(() => _database.Set
+            return AsyncHelper.RunSync(() => _database.Set
                 .Find(Builders<SetDto>.Filter.Eq(_ => _.Key, key) &
                       Builders<SetDto>.Filter.Gte(_ => _.Score, fromScore) &
                       Builders<SetDto>.Filter.Lte(_ => _.Score, toScore))
-                .Sort(Builders<SetDto>.Sort.Ascending(_ => _.Score))
+                .SortBy(_ => _.Score)
+                .Project(_ => _.Value)
                 .FirstOrDefaultAsync());
-
-            return set != null ? set.Value : null;
         }
 
         public override void SetRangeInHash(string key, IEnumerable<KeyValuePair<string, string>> keyValuePairs)
@@ -312,8 +313,9 @@ namespace Hangfire.Mongo
             if (key == null)
                 throw new ArgumentNullException("key");
 
-            Dictionary<string, string> result = AsyncHelper.RunSync(() => _database.Hash.Find(Builders<HashDto>.Filter.Eq(_ => _.Key, key)).ToListAsync())
-                .ToDictionary(x => x.Field, x => x.Value);
+            Dictionary<string, string> result = AsyncHelper.RunSync(() => _database.Hash
+                .Find(Builders<HashDto>.Filter.Eq(_ => _.Key, key))
+                .ToListAsync()).ToDictionary(x => x.Field, x => x.Value);
 
             return result.Count != 0 ? result : null;
         }
@@ -323,7 +325,9 @@ namespace Hangfire.Mongo
             if (key == null)
                 throw new ArgumentNullException("key");
 
-            return AsyncHelper.RunSync(() => _database.Set.Find(Builders<SetDto>.Filter.Eq(_ => _.Key, key)).CountAsync());
+            return AsyncHelper.RunSync(() => _database.Set
+                .Find(Builders<SetDto>.Filter.Eq(_ => _.Key, key))
+                .CountAsync());
         }
 
         public override List<string> GetRangeFromSet(string key, int startingFrom, int endingAt)
@@ -332,12 +336,11 @@ namespace Hangfire.Mongo
                 throw new ArgumentNullException("key");
 
             return AsyncHelper.RunSync(() => _database.Set
-                    .Find(Builders<SetDto>.Filter.Eq(_ => _.Key, key))
-                    .ToListAsync())
-                .Select((data, i) => new { Index = i + 1, Data = data })
-                .Where(_ => (_.Index >= startingFrom + 1) && (_.Index <= endingAt + 1))
-                .Select(x => x.Data.Value)
-                .ToList();
+                .Find(Builders<SetDto>.Filter.Eq(_ => _.Key, key))
+                .Skip(startingFrom)
+                .Limit(endingAt - startingFrom + 1) // inclusive -- ensure the last element is included
+                .Project(dto => dto.Value)
+                .ToListAsync()).ToList();
         }
 
         public override TimeSpan GetSetTtl(string key)
@@ -345,10 +348,10 @@ namespace Hangfire.Mongo
             if (key == null)
                 throw new ArgumentNullException("key");
 
-            DateTime[] values = AsyncHelper.RunSync(() => _database.Set.Find(Builders<SetDto>.Filter.Eq(_ => _.Key, key)).ToListAsync())
-                    .Where(_ => _.ExpireAt.HasValue)
-                    .Select(_ => _.ExpireAt.Value)
-                    .ToArray();
+            DateTime[] values = AsyncHelper.RunSync(() => _database.Set
+                .Find(Builders<SetDto>.Filter.Eq(_ => _.Key, key) & Builders<SetDto>.Filter.Not(Builders<SetDto>.Filter.Eq(_ => _.ExpireAt, null)))
+                .Project(dto => dto.ExpireAt.Value)
+                .ToListAsync()).ToArray();
 
             if (values.Any() == false)
                 return TimeSpan.FromSeconds(-1);
@@ -361,9 +364,17 @@ namespace Hangfire.Mongo
             if (key == null)
                 throw new ArgumentNullException("key");
 
-            long[] values = AsyncHelper.RunSync(() => _database.Counter.Find(Builders<CounterDto>.Filter.Eq(_ => _.Key, key)).ToListAsync()).Select(_ => (long)_.Value)
-                .Concat(AsyncHelper.RunSync(() => _database.AggregatedCounter.Find(Builders<AggregatedCounterDto>.Filter.Eq(_ => _.Key, key)).ToListAsync()).Select(_ => _.Value))
-                .ToArray();
+            List<long> counterQuery = AsyncHelper.RunSync(() => _database.Counter
+                .Find(Builders<CounterDto>.Filter.Eq(_ => _.Key, key))
+                .Project(_ => (long)_.Value)
+                .ToListAsync());
+
+            List<long> aggregatedCounterQuery = AsyncHelper.RunSync(() => _database.AggregatedCounter
+                .Find(Builders<AggregatedCounterDto>.Filter.Eq(_ => _.Key, key))
+                .Project(_ => _.Value)
+                .ToListAsync());
+
+            long[] values = counterQuery.Concat(aggregatedCounterQuery).ToArray();
 
             return values.Any() ? values.Sum() : 0;
         }
@@ -373,16 +384,20 @@ namespace Hangfire.Mongo
             if (key == null)
                 throw new ArgumentNullException("key");
 
-            return AsyncHelper.RunSync(() =>
-                _database.Hash.Find(Builders<HashDto>.Filter.Eq(_ => _.Key, key)).CountAsync());
+            return AsyncHelper.RunSync(() => _database.Hash
+                .Find(Builders<HashDto>.Filter.Eq(_ => _.Key, key))
+                .CountAsync());
         }
 
         public override TimeSpan GetHashTtl(string key)
         {
             if (key == null) throw new ArgumentNullException("key");
 
-            List<HashDto> hashes = AsyncHelper.RunSync(() => _database.Hash.Find(Builders<HashDto>.Filter.Eq(_ => _.Key, key)).ToListAsync());
-            DateTime? result = hashes.Any() ? hashes.Min(x => x.ExpireAt) : null;
+            DateTime? result = AsyncHelper.RunSync(() => _database.Hash
+                .Find(Builders<HashDto>.Filter.Eq(_ => _.Key, key))
+                .SortBy(dto => dto.ExpireAt)
+                .Project(_ => _.ExpireAt)
+                .FirstOrDefaultAsync());
 
             if (!result.HasValue)
                 return TimeSpan.FromSeconds(-1);
@@ -410,8 +425,9 @@ namespace Hangfire.Mongo
             if (key == null)
                 throw new ArgumentNullException("key");
 
-            return AsyncHelper.RunSync(() =>
-                _database.List.Find(Builders<ListDto>.Filter.Eq(_ => _.Key, key)).CountAsync());
+            return AsyncHelper.RunSync(() => _database.List
+                .Find(Builders<ListDto>.Filter.Eq(_ => _.Key, key))
+                .CountAsync());
         }
 
         public override TimeSpan GetListTtl(string key)
@@ -419,8 +435,11 @@ namespace Hangfire.Mongo
             if (key == null)
                 throw new ArgumentNullException("key");
 
-            List<ListDto> items = AsyncHelper.RunSync(() => _database.List.Find(Builders<ListDto>.Filter.Eq(_ => _.Key, key)).ToListAsync());
-            DateTime? result = items.Any() ? items.Min(_ => _.ExpireAt) : null;
+            DateTime? result = AsyncHelper.RunSync(() =>_database.List
+                .Find(Builders<ListDto>.Filter.Eq(_ => _.Key, key))
+                .SortBy(_ => _.ExpireAt)
+                .Project(_ => _.ExpireAt)
+                .FirstOrDefaultAsync());
 
             if (!result.HasValue)
                 return TimeSpan.FromSeconds(-1);
@@ -433,11 +452,12 @@ namespace Hangfire.Mongo
             if (key == null)
                 throw new ArgumentNullException("key");
 
-            return AsyncHelper.RunSync(() => _database.List.Find(Builders<ListDto>.Filter.Eq(_ => _.Key, key)).ToListAsync())
-                .Select((data, i) => new { Index = i + 1, Data = data })
-                .Where(_ => (_.Index >= startingFrom + 1) && (_.Index <= endingAt + 1))
-                .Select(x => x.Data.Value)
-                .ToList();
+            return AsyncHelper.RunSync(() => _database.List
+                .Find(Builders<ListDto>.Filter.Eq(_ => _.Key, key))
+                .Skip(startingFrom)
+                .Limit(endingAt - startingFrom + 1) // inclusive -- ensure the last element is included
+                .Project(dto => dto.Value)
+                .ToListAsync());
         }
 
         public override List<string> GetAllItemsFromList(string key)
@@ -445,9 +465,10 @@ namespace Hangfire.Mongo
             if (key == null)
                 throw new ArgumentNullException("key");
 
-            return AsyncHelper.RunSync(() => _database.List.Find(Builders<ListDto>.Filter.Eq(_ => _.Key, key)).ToListAsync())
-                .Select(_ => _.Value)
-                .ToList();
+            return AsyncHelper.RunSync(() => _database.List
+                .Find(Builders<ListDto>.Filter.Eq(_ => _.Key, key))
+                .Project(_ => _.Value)
+                .ToListAsync());
         }
     }
 #pragma warning restore 1591

--- a/src/Hangfire.Mongo/MongoConnection.cs
+++ b/src/Hangfire.Mongo/MongoConnection.cs
@@ -265,7 +265,7 @@ namespace Hangfire.Mongo
 
             IEnumerable<string> result = AsyncHelper.RunSync(() => _database.Set
                 .Find(Builders<SetDto>.Filter.Eq(_ => _.Key, key))
-                .Project(dto => dto.Value)
+                .Project(_ => _.Value)
                 .ToListAsync());
 
             return new HashSet<string>(result);
@@ -456,7 +456,7 @@ namespace Hangfire.Mongo
                 .Find(Builders<ListDto>.Filter.Eq(_ => _.Key, key))
                 .Skip(startingFrom)
                 .Limit(endingAt - startingFrom + 1) // inclusive -- ensure the last element is included
-                .Project(dto => dto.Value)
+                .Project(_ => _.Value)
                 .ToListAsync());
         }
 

--- a/src/Hangfire.Mongo/PersistentJobQueue/Mongo/MongoJobQueueMonitoringApi.cs
+++ b/src/Hangfire.Mongo/PersistentJobQueue/Mongo/MongoJobQueueMonitoringApi.cs
@@ -47,7 +47,7 @@ namespace Hangfire.Mongo.PersistentJobQueue.Mongo
                     var job = AsyncHelper.RunSync(() => _connection.Job.Find(Builders<JobDto>.Filter.Eq(_ => _.Id, jobQueue.JobId)).FirstOrDefaultAsync());
                     return (job != null) && (AsyncHelper.RunSync(() => _connection.State.Find(Builders<StateDto>.Filter.Eq(_ => _.Id, job.StateId)).FirstOrDefaultAsync()) != null);
                 })
-                .Select(jobQueue => jobQueue.Id)
+                .Select(jobQueue => jobQueue.JobId)
                 .ToArray();
         }
 


### PR DESCRIPTION
This improves the performance for interaction with the Mongo layer substantially by returning only the minimum data necessary when a request is done.  Primary changes include:
 - Switching use of Linq `Skip` and `Take` to use Mongo commands `Skip` and `Limit`;
 - Switching use of Linq `Select` to use Mongo commands `Project`;

For cases requiring a JOIN of sorts, I have switched to querying the minimal information on the primary dataset first (in most cases `JobDto` to return the `Id` field), then querying the filter datasets (e.g. `JobQueueDto` or `StateDto`) to do the filtering before then querying the primary dataset for the actual complete objects.  This has the most noticable and largest improvement on the Dashboard, where to get the jobs it was getting the entire dataset in memory and using Linq to filter.

I also added tests for the `MongoMonitoringApi` to ensure that I didn't break anything between the existing code and these changes.

Please let me know if any of this is incorrect with the design goals/does not make sense.