### PR TITLE
Added possibility to use MongoClient settings instead of a connection…

### DIFF
--- a/src/Hangfire.Mongo.Sample/Hangfire.Mongo.Sample.csproj
+++ b/src/Hangfire.Mongo.Sample/Hangfire.Mongo.Sample.csproj
@@ -25,6 +25,8 @@
     <UseGlobalApplicationHostFile />
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -59,6 +61,10 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="MongoDB.Bson, Version=2.1.1.5, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MongoDB.Bson.2.1.1\lib\net45\MongoDB.Bson.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="MongoDB.Driver, Version=2.1.1.5, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Driver.2.1.1\lib\net45\MongoDB.Driver.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MongoDB.Driver.Core, Version=2.1.1.5, Culture=neutral, processorArchitecture=MSIL">
@@ -274,7 +280,9 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.1\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.1\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.1.1.1\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.1.1.1\build\Microsoft.Net.Compilers.props'))" />
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
   </Target>
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/Hangfire.Mongo.Tests/MongoStorageFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoStorageFacts.cs
@@ -13,9 +13,9 @@ namespace Hangfire.Mongo.Tests
     public class MongoStorageFacts
     {
         [Fact]
-        public void Ctor_ThrowsAnException_WhenConnectionStringIsNull()
+        public void Ctor_ThrowsAnException_WhenConnectionStringIsEmpty()
         {
-            var exception = Assert.Throws<ArgumentNullException>(() => new MongoStorage(null, "database"));
+            var exception = Assert.Throws<ArgumentNullException>(() => new MongoStorage("", "database"));
 
             Assert.Equal("connectionString", exception.ParamName);
         }

--- a/src/Hangfire.Mongo/Database/HangfireDbContext.cs
+++ b/src/Hangfire.Mongo/Database/HangfireDbContext.cs
@@ -35,6 +35,23 @@ namespace Hangfire.Mongo.Database
             ConnectionId = Guid.NewGuid().ToString();
         }
 
+		/// <summary>
+		/// Constructs context with Mongo client settings and database name
+		/// </summary>
+		/// <param name="mongoClientSettings">Client settings for MongoDB</param>
+		/// <param name="databaseName">Database name</param>
+		/// <param name="prefix">Collections prefix</param>
+		public HangfireDbContext(MongoClientSettings mongoClientSettings, string databaseName, string prefix = "hangfire")
+		{
+			_prefix = prefix;
+
+			MongoClient client = new MongoClient(mongoClientSettings);
+
+			Database = client.GetDatabase(databaseName);
+
+			ConnectionId = Guid.NewGuid().ToString();
+		}
+
         /// <summary>
         /// Constructs context with existing Mongo database connection
         /// </summary>

--- a/src/Hangfire.Mongo/MongoBootstrapperConfigurationExtensions.cs
+++ b/src/Hangfire.Mongo/MongoBootstrapperConfigurationExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using MongoDB.Driver;
 
 namespace Hangfire.Mongo
 {
@@ -47,6 +48,46 @@ namespace Hangfire.Mongo
             return storage;
         }
 
+		/// <summary>
+		/// Configure Hangfire to use MongoDB storage
+		/// </summary>
+		/// <param name="configuration">Configuration</param>
+		/// <param name="mongoClientSettings">Client settings for Mongo</param>
+		/// <param name="databaseName">Name of database at Mongo server</param>
+		/// <returns></returns>
+		[Obsolete("Please use `GlobalConfiguration.UseStorage` instead. Will be removed in Hangfire version 2.0.0.")]
+		public static MongoStorage UseMongoStorage(this IBootstrapperConfiguration configuration,
+			MongoClientSettings mongoClientSettings,
+			string databaseName)
+		{
+			MongoStorage storage = new MongoStorage(mongoClientSettings, databaseName);
+
+			configuration.UseStorage(storage);
+
+			return storage;
+		}
+
+		/// <summary>
+		/// Configure Hangfire to use MongoDB storage
+		/// </summary>
+		/// <param name="configuration">Configuration</param>
+		/// <param name="mongoClientSettings">Client settings for Mongo</param>
+		/// <param name="databaseName">Name of database at Mongo server</param>
+		/// <param name="options">Storage options</param>
+		/// <returns></returns>
+		[Obsolete("Please use `GlobalConfiguration.UseStorage` instead. Will be removed in Hangfire version 2.0.0.")]
+		public static MongoStorage UseMongoStorage(this IBootstrapperConfiguration configuration,
+			MongoClientSettings mongoClientSettings,
+			string databaseName,
+			MongoStorageOptions options)
+		{
+			MongoStorage storage = new MongoStorage(mongoClientSettings, databaseName, options);
+
+			configuration.UseStorage(storage);
+
+			return storage;
+		}
+
         /// <summary>
         /// Configure Hangfire to use MongoDB storage
         /// </summary>
@@ -84,5 +125,43 @@ namespace Hangfire.Mongo
 
             return storage;
         }
+
+		/// <summary>
+		/// Configure Hangfire to use MongoDB storage
+		/// </summary>
+		/// <param name="configuration">Configuration</param>
+		/// <param name="mongoClientSettings">Client settings for Mongo</param>
+		/// <param name="databaseName">Name of database at Mongo server</param>
+		/// <returns></returns>
+		public static MongoStorage UseMongoStorage(this IGlobalConfiguration configuration,
+			MongoClientSettings mongoClientSettings,
+			string databaseName)
+		{
+			MongoStorage storage = new MongoStorage(mongoClientSettings, databaseName, new MongoStorageOptions());
+
+			configuration.UseStorage(storage);
+
+			return storage;
+		}
+
+		/// <summary>
+		/// Configure Hangfire to use MongoDB storage
+		/// </summary>
+		/// <param name="configuration">Configuration</param>
+		/// <param name="mongoClientSettings">Client settings for Mongo</param>
+		/// <param name="databaseName">Name of database at Mongo server</param>
+		/// <param name="options">Storage options</param>
+		/// <returns></returns>
+		public static MongoStorage UseMongoStorage(this IGlobalConfiguration configuration,
+			MongoClientSettings mongoClientSettings,
+			string databaseName,
+			MongoStorageOptions options)
+		{
+			MongoStorage storage = new MongoStorage(mongoClientSettings, databaseName, options);
+
+			configuration.UseStorage(storage);
+
+			return storage;
+		}
     }
 }

--- a/src/Hangfire.Mongo/MongoStorage.cs
+++ b/src/Hangfire.Mongo/MongoStorage.cs
@@ -9,6 +9,7 @@ using Hangfire.Storage;
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using MongoDB.Driver;
 
 namespace Hangfire.Mongo
 {
@@ -36,7 +37,7 @@ namespace Hangfire.Mongo
         }
 
         /// <summary>
-        /// Constructs Job Storage by database connection string, name andoptions
+        /// Constructs Job Storage by database connection string, name and options
         /// </summary>
         /// <param name="connectionString">MongoDB connection string</param>
         /// <param name="databaseName">Database name</param>
@@ -60,6 +61,41 @@ namespace Hangfire.Mongo
             var defaultQueueProvider = new MongoJobQueueProvider(options);
             QueueProviders = new PersistentJobQueueProviderCollection(defaultQueueProvider);
         }
+
+		/// <summary>
+		/// Constructs Job Storage by Mongo client settings and name
+		/// </summary>
+		/// <param name="mongoClientSettings">Client settings for MongoDB</param>
+		/// <param name="databaseName">Database name</param>
+		public MongoStorage(MongoClientSettings mongoClientSettings, string databaseName)
+			: this(mongoClientSettings, databaseName, new MongoStorageOptions())
+		{
+		}
+
+		/// <summary>
+		/// Constructs Job Storage by Mongo client settings, name and options
+		/// </summary>
+		/// <param name="mongoClientSettings">Client settings for MongoDB</param>
+		/// <param name="databaseName">Database name</param>
+		/// <param name="options">Storage options</param>
+		public MongoStorage(MongoClientSettings mongoClientSettings, string databaseName, MongoStorageOptions options)
+		{
+			if (mongoClientSettings == null)
+				throw new ArgumentNullException("mongoClientSettings");
+
+			if (String.IsNullOrWhiteSpace(databaseName) == true)
+				throw new ArgumentNullException("databaseName");
+
+			if (options == null)
+				throw new ArgumentNullException("options");
+
+			_databaseName = databaseName;
+			_options = options;
+
+			Connection = new HangfireDbContext(mongoClientSettings, databaseName, options.Prefix);
+			var defaultQueueProvider = new MongoJobQueueProvider(options);
+			QueueProviders = new PersistentJobQueueProviderCollection(defaultQueueProvider);
+		}
 
         /// <summary>
         /// Database context


### PR DESCRIPTION
I would like to use Hangfire with MongoDB as storage in an IPv6 environment.
As far as I know it is not possible to configure the MongoDB .NET driver to use IPv6 using a connection string. (Option "?ipv6=true" has no effect)

The MongoClient class has a constructor that accepts MongoClientSettings, which can be configured to make the client work with IPv6:

```
new MongoClientSettings()
{
	IPv6 = true,
}
```

In this branch i added an overload for the UseMongoStorage that takes a MongoClientSettings object instead of a connection string.