### PR TITLE
Make nuget package more compatible

### DIFF
--- a/nuspecs/HangFire.Mongo.nuspec
+++ b/nuspecs/HangFire.Mongo.nuspec
@@ -36,7 +36,7 @@
         </dependencies>
     </metadata>
     <files>
-        <file src="Net45\Hangfire.Mongo\Hangfire.Mongo.dll" target="lib\Hangfire.Mongo.dll" />
-        <file src="Net45\Hangfire.Mongo\Hangfire.Mongo.XML" target="lib\Hangfire.Mongo.XML" />
+        <file src="Net45\Hangfire.Mongo\Hangfire.Mongo.dll" target="lib\net45" />
+        <file src="Net45\Hangfire.Mongo\Hangfire.Mongo.XML" target="lib\net45" />
     </files>
 </package>

--- a/src/Hangfire.Mongo.Sample/Hangfire.Mongo.Sample.csproj
+++ b/src/Hangfire.Mongo.Sample/Hangfire.Mongo.Sample.csproj
@@ -15,7 +15,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Hangfire.Mongo.Sample</RootNamespace>
     <AssemblyName>Hangfire.Mongo.Sample</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>true</UseIISExpress>
     <IISExpressSSLPort />
@@ -25,6 +25,7 @@
     <UseGlobalApplicationHostFile />
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -57,12 +58,12 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="MongoDB.Bson, Version=2.1.1.5, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MongoDB.Bson.2.1.1\lib\net45\MongoDB.Bson.dll</HintPath>
+    <Reference Include="MongoDB.Bson, Version=2.2.3.3, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Bson.2.2.3\lib\net45\MongoDB.Bson.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="MongoDB.Driver.Core, Version=2.1.1.5, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MongoDB.Driver.Core.2.1.1\lib\net45\MongoDB.Driver.Core.dll</HintPath>
+    <Reference Include="MongoDB.Driver.Core, Version=2.2.3.3, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Driver.Core.2.2.3\lib\net45\MongoDB.Driver.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -71,16 +72,14 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Web.Abstractions" />
     <Reference Include="System.Web.Routing" />
     <Reference Include="System.Xml" />
@@ -122,6 +121,7 @@
       <Private>True</Private>
       <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
     </Reference>
+    <Reference Include="System.Xml.Linq" />
     <Reference Include="WebGrease, Version=1.6.5135.21930, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\WebGrease.1.6.0\lib\WebGrease.dll</HintPath>
       <Private>True</Private>

--- a/src/Hangfire.Mongo.Sample/Web.config
+++ b/src/Hangfire.Mongo.Sample/Web.config
@@ -17,10 +17,18 @@
     <add key="ClientValidationEnabled" value="true" />
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
   </appSettings>
+  <!--
+    For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
+
+    The following attributes can be set on the <httpRuntime> tag.
+      <system.Web>
+        <httpRuntime targetFramework="4.5" />
+      </system.Web>
+  -->
   <system.web>
     <authentication mode="None" />
-    <compilation debug="true" targetFramework="4.5.2" />
-    <httpRuntime targetFramework="4.5.2" />
+    <compilation debug="true" targetFramework="4.5" />
+    <httpRuntime targetFramework="4.5" />
   </system.web>
   <system.webServer>
     <modules>

--- a/src/Hangfire.Mongo.Sample/packages.config
+++ b/src/Hangfire.Mongo.Sample/packages.config
@@ -27,8 +27,8 @@
   <package id="Microsoft.Owin.Security.Twitter" version="3.0.1" targetFramework="net452" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net452" />
   <package id="Modernizr" version="2.8.3" targetFramework="net452" />
-  <package id="MongoDB.Bson" version="2.1.1" targetFramework="net452" />
-  <package id="MongoDB.Driver.Core" version="2.1.1" targetFramework="net452" />
+  <package id="MongoDB.Bson" version="2.2.3" targetFramework="net45" />
+  <package id="MongoDB.Driver.Core" version="2.2.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
   <package id="Owin" version="1.0" targetFramework="net452" />
   <package id="Respond" version="1.4.2" targetFramework="net452" />

--- a/src/Hangfire.Mongo.Tests/Hangfire.Mongo.Tests.csproj
+++ b/src/Hangfire.Mongo.Tests/Hangfire.Mongo.Tests.csproj
@@ -39,16 +39,16 @@
       <HintPath>..\packages\Hangfire.Core.1.5.3\lib\net45\Hangfire.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="MongoDB.Bson, Version=2.1.1.5, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MongoDB.Bson.2.1.1\lib\net45\MongoDB.Bson.dll</HintPath>
+    <Reference Include="MongoDB.Bson, Version=2.2.3.3, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Bson.2.2.3\lib\net45\MongoDB.Bson.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="MongoDB.Driver, Version=2.1.1.5, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MongoDB.Driver.2.1.1\lib\net45\MongoDB.Driver.dll</HintPath>
+    <Reference Include="MongoDB.Driver, Version=2.2.3.3, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Driver.2.2.3\lib\net45\MongoDB.Driver.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="MongoDB.Driver.Core, Version=2.1.1.5, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MongoDB.Driver.Core.2.1.1\lib\net45\MongoDB.Driver.Core.dll</HintPath>
+    <Reference Include="MongoDB.Driver.Core, Version=2.2.3.3, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Driver.Core.2.2.3\lib\net45\MongoDB.Driver.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">

--- a/src/Hangfire.Mongo.Tests/packages.config
+++ b/src/Hangfire.Mongo.Tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Hangfire.Core" version="1.5.3" targetFramework="net451" />
-  <package id="MongoDB.Bson" version="2.1.1" targetFramework="net451" />
-  <package id="MongoDB.Driver" version="2.1.1" targetFramework="net451" />
-  <package id="MongoDB.Driver.Core" version="2.1.1" targetFramework="net451" />
+  <package id="MongoDB.Bson" version="2.2.3" targetFramework="net451" />
+  <package id="MongoDB.Driver" version="2.2.3" targetFramework="net451" />
+  <package id="MongoDB.Driver.Core" version="2.2.3" targetFramework="net451" />
   <package id="Moq" version="4.2.1510.2205" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net451" />
   <package id="Owin" version="1.0" targetFramework="net451" />

--- a/src/Hangfire.Mongo/Hangfire.Mongo.csproj
+++ b/src/Hangfire.Mongo/Hangfire.Mongo.csproj
@@ -9,10 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Hangfire.Mongo</RootNamespace>
     <AssemblyName>Hangfire.Mongo</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -44,16 +45,16 @@
       <HintPath>..\packages\Hangfire.Core.1.5.3\lib\net45\Hangfire.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="MongoDB.Bson, Version=2.1.1.5, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MongoDB.Bson.2.1.1\lib\net45\MongoDB.Bson.dll</HintPath>
+    <Reference Include="MongoDB.Bson, Version=2.2.3.3, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Bson.2.2.3\lib\net45\MongoDB.Bson.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="MongoDB.Driver, Version=2.1.1.5, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MongoDB.Driver.2.1.1\lib\net45\MongoDB.Driver.dll</HintPath>
+    <Reference Include="MongoDB.Driver, Version=2.2.3.3, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Driver.2.2.3\lib\net45\MongoDB.Driver.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="MongoDB.Driver.Core, Version=2.1.1.5, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MongoDB.Driver.Core.2.1.1\lib\net45\MongoDB.Driver.Core.dll</HintPath>
+    <Reference Include="MongoDB.Driver.Core, Version=2.2.3.3, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Driver.Core.2.2.3\lib\net45\MongoDB.Driver.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/src/Hangfire.Mongo/app.config
+++ b/src/Hangfire.Mongo/app.config
@@ -8,4 +8,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" /></startup></configuration>

--- a/src/Hangfire.Mongo/packages.config
+++ b/src/Hangfire.Mongo/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Hangfire.Core" version="1.5.3" targetFramework="net451" />
-  <package id="MongoDB.Bson" version="2.1.1" targetFramework="net451" />
-  <package id="MongoDB.Driver" version="2.1.1" targetFramework="net451" />
-  <package id="MongoDB.Driver.Core" version="2.1.1" targetFramework="net451" />
+  <package id="MongoDB.Bson" version="2.2.3" targetFramework="net45" />
+  <package id="MongoDB.Driver" version="2.2.3" targetFramework="net45" />
+  <package id="MongoDB.Driver.Core" version="2.2.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net451" />
   <package id="Owin" version="1.0" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
Changes suggested:
Change target framework to .NET 4.5
Update Hangfire.Mongo.nuspec to align to nuget standard folder structure.
Update to latest MongoDB.Driver (2.2.3)

Im not an expert in multiple nuget targets, so i didnt add multiple build configurations for the latest frameworks. Im thinking targeting 4.5 should suffice for now.