### PR TITLE
Fix FormatException Issue

### DIFF
--- a/src/Hangfire.Mongo/MongoUtils/MongoExtensions.cs
+++ b/src/Hangfire.Mongo/MongoUtils/MongoExtensions.cs
@@ -26,11 +26,7 @@ namespace Hangfire.Mongo.MongoUtils
             catch (MongoException)
             {
                 return DateTime.UtcNow;
-			}
-			catch (FormatException)
-			{
-				return DateTime.UtcNow;
-			}
+            }
         }
 
         /// <summary>

--- a/src/Hangfire.Mongo/MongoUtils/MongoExtensions.cs
+++ b/src/Hangfire.Mongo/MongoUtils/MongoExtensions.cs
@@ -26,7 +26,11 @@ namespace Hangfire.Mongo.MongoUtils
             catch (MongoException)
             {
                 return DateTime.UtcNow;
-            }
+			}
+			catch (FormatException)
+			{
+				return DateTime.UtcNow;
+			}
         }
 
         /// <summary>

--- a/src/Hangfire.Mongo/MongoUtils/MongoExtensions.cs
+++ b/src/Hangfire.Mongo/MongoUtils/MongoExtensions.cs
@@ -19,14 +19,20 @@ namespace Hangfire.Mongo.MongoUtils
         /// <returns>Server time</returns>
         public static DateTime GetServerTimeUtc(this IMongoDatabase database)
         {
-			dynamic serverStatus = AsyncHelper.RunSync(() => database.RunCommandAsync<dynamic>(new BsonDocument("isMaster", 1)));
-	        object localTime;
-			if (((IDictionary<string, object>)serverStatus).TryGetValue("localTime", out localTime))
+	        try
+	        {
+				dynamic serverStatus = AsyncHelper.RunSync(() => database.RunCommandAsync<dynamic>(new BsonDocument("isMaster", 1)));
+				object localTime;
+				if (((IDictionary<string, object>)serverStatus).TryGetValue("localTime", out localTime))
+				{
+					return ((DateTime)localTime).ToUniversalTime();
+				}
+				return DateTime.UtcNow;
+	        }
+	        catch (FormatException)
 			{
-				return ((DateTime)localTime).ToUniversalTime();
-			}
-
-			return DateTime.UtcNow;
+				return DateTime.UtcNow;
+	        }
         }
 
         /// <summary>


### PR DESCRIPTION
Hangfire.Mongo runs the isMaster Command on MongoDB, to get the local time from the database.
Depeding on the result, this may cause a FormatException in the MongoDb.Driver.

Response that works:
```
{
	"ismaster" : true,
	"maxBsonObjectSize" : 16777216,
	"maxMessageSizeBytes" : 48000000,
	"maxWriteBatchSize" : 1000,
	"localTime" : ISODate("2016-02-19T13:03:25.244Z"),
	"maxWireVersion" : 4,
	"minWireVersion" : 0,
	"ok" : 1
}
```

Response that causes FormatException:
```

{
        "hosts" : [
                "ob1.fus.cated:27017",
                "ob2.fus.cated:27017"
        ],
        "setName" : "replicaset1",
        "setVersion" : 2,
        "ismaster" : true,
        "secondary" : false,
        "primary" : "ob1.fus.cated:27017",
        "me" : "ob1.fus.cated:27017",
        "electionId" : ObjectId("56c45d823d4404a3b330555d"),
        "maxBsonObjectSize" : 16777216,
        "maxMessageSizeBytes" : 48000000,
        "maxWriteBatchSize" : 1000,
        "localTime" : ISODate("2016-02-19T13:07:36.218Z"),
        "maxWireVersion" : 4,
        "minWireVersion" : 0,
        "ok" : 1
}
```

As a fix this commit catches FormatExceptions caused during the command execution and returns the servers time instead.