### PR TITLE
Correcting casing in Hangfire.Mongo.nuspec

### DIFF
--- a/nuspecs/HangFire.Mongo.nuspec
+++ b/nuspecs/HangFire.Mongo.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
     <metadata>
-        <id>HangFire.Mongo</id>
+        <id>Hangfire.Mongo</id>
         <version>1.0.0</version>
         <title>Hangfire MongoDB Storage</title>
         <authors>Sergey Zwezdin</authors>
@@ -39,8 +39,8 @@
 * Initial public release
         </releaseNotes>
         <dependencies>
-            <dependency id="HangFire.Core" version="1.5.3" />
-            <dependency id="MongoDB.Driver" version="2.2.3" />
+            <dependency id="Hangfire.Core" version="1.5.3" />
+            <dependency id="MongoDB.Driver" version="2.1.1" />
         </dependencies>
     </metadata>
     <files>


### PR DESCRIPTION
The casing of the ID of the HangFire.Core dependency is off in the nuspec file, which causes this error in .NET Core RC2 (targeting full .NET platform): http://www.screencast.com/t/RGcD05w5N0