### PR TITLE
fix(MongoConnection) - locks for MongoWriteOnlyTransaction.Commit

### DIFF
--- a/src/Hangfire.Mongo.Tests/ExpirationManagerFacts.cs
+++ b/src/Hangfire.Mongo.Tests/ExpirationManagerFacts.cs
@@ -275,7 +275,7 @@ namespace Hangfire.Mongo.Tests
 
         private static void Commit(HangfireDbContext connection, Action<MongoWriteOnlyTransaction> action)
         {
-            using (MongoWriteOnlyTransaction transaction = new MongoWriteOnlyTransaction(connection, _queueProviders))
+            using (MongoWriteOnlyTransaction transaction = new MongoWriteOnlyTransaction(connection, _queueProviders, new MongoStorageOptions()))
             {
                 action(transaction);
                 transaction.Commit();

--- a/src/Hangfire.Mongo.Tests/Hangfire.Mongo.Tests.csproj
+++ b/src/Hangfire.Mongo.Tests/Hangfire.Mongo.Tests.csproj
@@ -52,6 +52,7 @@
     <Compile Include="MongoStorageFacts.cs" />
     <Compile Include="MongoStorageOptionsFacts.cs" />
     <Compile Include="MongoWriteOnlyTransactionFacts.cs" />
+    <Compile Include="MultipleServersFacts.cs" />
     <Compile Include="PersistentJobQueue\Mongo\MongoJobQueueMonitoringApiFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utils\CleanDatabaseAttribute.cs" />

--- a/src/Hangfire.Mongo.Tests/MongoWriteOnlyTransactionFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoWriteOnlyTransactionFacts.cs
@@ -31,7 +31,7 @@ namespace Hangfire.Mongo.Tests
         [Fact]
         public void Ctor_ThrowsAnException_IfConnectionIsNull()
         {
-            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() => new MongoWriteOnlyTransaction(null, _queueProviders));
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() => new MongoWriteOnlyTransaction(null, _queueProviders, new MongoStorageOptions()));
 
             Assert.Equal("connection", exception.ParamName);
         }
@@ -39,9 +39,17 @@ namespace Hangfire.Mongo.Tests
         [Fact, CleanDatabase]
         public void Ctor_ThrowsAnException_IfProvidersCollectionIsNull()
         {
-            var exception = Assert.Throws<ArgumentNullException>(() => new MongoWriteOnlyTransaction(ConnectionUtils.CreateConnection(), null));
+            var exception = Assert.Throws<ArgumentNullException>(() => new MongoWriteOnlyTransaction(ConnectionUtils.CreateConnection(), null, new MongoStorageOptions()));
 
             Assert.Equal("queueProviders", exception.ParamName);
+        }
+
+        [Fact, CleanDatabase]
+        public void Ctor_ThrowsAnException_IfMongoStorageOptionsIsNull()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(() => new MongoWriteOnlyTransaction(ConnectionUtils.CreateConnection(), _queueProviders, null));
+
+            Assert.Equal("options", exception.ParamName);
         }
 
         [Fact, CleanDatabase]
@@ -924,7 +932,7 @@ namespace Hangfire.Mongo.Tests
 
         private void Commit(HangfireDbContext connection, Action<MongoWriteOnlyTransaction> action)
         {
-            using (MongoWriteOnlyTransaction transaction = new MongoWriteOnlyTransaction(connection, _queueProviders))
+            using (MongoWriteOnlyTransaction transaction = new MongoWriteOnlyTransaction(connection, _queueProviders, new MongoStorageOptions()))
             {
                 action(transaction);
                 transaction.Commit();

--- a/src/Hangfire.Mongo.Tests/MultipleServersFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MultipleServersFacts.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading;
+using Hangfire.Common;
+using Hangfire.Mongo.Tests.Utils;
+using Xunit;
+
+namespace Hangfire.Mongo.Tests
+{
+#pragma warning disable 1591
+    [Collection("Database")]
+    public class MultipleServersFacts
+    {
+        private static int _serverCount = 5;
+        private static int _workerCount = 20;
+        private static AutoResetEvent[] _signals;
+
+        [/*Fact*/ Fact(Skip = "Long running and does not always fail"), CleanDatabase]
+        public void MultipleServerRunsRecurrentJobs()
+        {
+            // ARRANGE
+
+            var options = new BackgroundJobServerOptions[_serverCount];
+            var storage = new MongoStorage[_serverCount];
+            var servers = new BackgroundJobServer[_serverCount];
+            _signals = new AutoResetEvent[_serverCount];
+            var jobManagers = new RecurringJobManager[_serverCount];
+
+            for (int i = 0; i < _serverCount; i++)
+            {
+                options[i] = new BackgroundJobServerOptions {Queues = new[] {$"queue_options_{i}"}, WorkerCount = _workerCount };
+                storage[i] = new MongoStorage(ConnectionUtils.GetConnectionString(), ConnectionUtils.GetDatabaseName(),
+                    new MongoStorageOptions {QueuePollInterval = TimeSpan.FromSeconds(1)});
+
+                servers[i] = new BackgroundJobServer(options[i], storage[i]);
+                jobManagers[i] = new RecurringJobManager(storage[i]);
+                _signals[i] = new AutoResetEvent(false);
+            }
+            try
+            {
+                // ACT
+                for (int i = 0; i < _serverCount; i++)
+                {
+                    var i1 = i;
+                    var jobManager = jobManagers[i1];
+                    
+                    for (int j = 0; j < _workerCount; j++)
+                    {
+                        var j1 = j;
+                        var queueIndex = j1 % options[i1].Queues.Length;
+                        var queueName = options[i1].Queues[queueIndex];
+                        var job = Job.FromExpression(() => SetSignal(queueName, i1));
+                        var jobId = Guid.NewGuid().ToString("N");
+
+                        jobManager.AddOrUpdate(jobId, job, Cron.Minutely(), new RecurringJobOptions
+                        {
+                            QueueName = queueName
+                        });
+                    }
+                }
+                WaitHandle.WaitAll(_signals);
+                // ASSERT
+                // no exceptions
+            }
+            finally
+            {
+                for (int i = 0; i < _serverCount; i++)
+                {
+                    servers[i].SendStop();
+                    servers[i].Dispose();
+                    _signals[i].Dispose();
+                }
+            }
+        }
+
+        public static void SetSignal(string queueName, int index)
+        {
+            Debug.WriteLine("Setting signal for queue {0}", queueName);
+            _signals[index].Set();
+        }
+    }
+#pragma warning restore 1591
+}

--- a/src/Hangfire.Mongo/Database/HangfireDbContext.cs
+++ b/src/Hangfire.Mongo/Database/HangfireDbContext.cs
@@ -2,9 +2,7 @@
 using System.Reflection;
 using Hangfire.Mongo.DistributedLock;
 using Hangfire.Mongo.Dto;
-using Hangfire.Mongo.MongoUtils;
 using MongoDB.Bson;
-using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
 
 namespace Hangfire.Mongo.Database
@@ -140,6 +138,7 @@ namespace Hangfire.Mongo.Database
         private void CreateJobIndexes()
         {
             // Create for jobid jobQueue
+            StateData.Indexes.CreateOne(Builders<KeyValueDto>.IndexKeys.Ascending(_ => _.Key));
         }
 
 


### PR DESCRIPTION
We can avoid the lock if we model our dto's better.
   - This will be done when we have a migration strategy in place.

+ Added index to "Key" field for KeyValueDto