### PR TITLE
Reactive Mongo

### DIFF
--- a/build/clean.sh
+++ b/build/clean.sh
@@ -1,0 +1,4 @@
+rm -rf src/packages
+find . -name bin -print0 | xargs -0 rm -rf
+find . -name obj -print0 | xargs -0 rm -rf
+

--- a/src/Hangfire.Mongo.Sample.ASPNetCore/Startup.cs
+++ b/src/Hangfire.Mongo.Sample.ASPNetCore/Startup.cs
@@ -29,17 +29,16 @@ namespace Hangfire.Mongo.Sample.ASPNetCore
                 // Read DefaultConnection string from appsettings.json
                 var connectionString = Configuration.GetConnectionString("DefaultConnection");
 
-                var migrationOptions = new MongoStorageOptions
+                var storageOptions = new MongoStorageOptions
                 {
                     MigrationOptions = new MongoMigrationOptions
                     {
                         Strategy = MongoMigrationStrategy.Migrate,
                     }
                 };
-                config.UseMongoStorage(connectionString, "hangfire-mongo-sample-aspnetcore", migrationOptions);
+                config.UseMongoStorage(connectionString, "hangfire-mongo-sample-aspnetcore", storageOptions);
             });
             services.AddMvc();
-
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/Hangfire.Mongo.Tests/CountersAggregatorFacts.cs
+++ b/src/Hangfire.Mongo.Tests/CountersAggregatorFacts.cs
@@ -7,7 +7,6 @@ using Xunit;
 
 namespace Hangfire.Mongo.Tests
 {
-#pragma warning disable 1591
     [Collection("Database")]
     public class CountersAggregatorFacts
     {
@@ -37,5 +36,4 @@ namespace Hangfire.Mongo.Tests
             }
         }
     }
-#pragma warning restore 1591
 }

--- a/src/Hangfire.Mongo.Tests/CountersAggregatorFacts.cs
+++ b/src/Hangfire.Mongo.Tests/CountersAggregatorFacts.cs
@@ -25,11 +25,13 @@ namespace Hangfire.Mongo.Tests
                 });
 
                 var aggregator = new CountersAggregator(storage, TimeSpan.Zero);
-                var cts = new CancellationTokenSource();
-                cts.Cancel();
 
                 // Act
-                aggregator.Execute(cts.Token);
+                using (var cts = new CancellationTokenSource())
+                {
+                    cts.Cancel();
+                    aggregator.Execute(cts.Token);
+                }
 
                 // Assert
                 Assert.Equal(1, connection.Database.StateData.OfType<AggregatedCounterDto>().Count(new BsonDocument()));

--- a/src/Hangfire.Mongo.Tests/ExpirationManagerFacts.cs
+++ b/src/Hangfire.Mongo.Tests/ExpirationManagerFacts.cs
@@ -11,7 +11,6 @@ using Xunit;
 
 namespace Hangfire.Mongo.Tests
 {
-#pragma warning disable 1591
     [Collection("Database")]
     public class ExpirationManagerFacts
     {
@@ -281,5 +280,4 @@ namespace Hangfire.Mongo.Tests
             }
         }
     }
-#pragma warning restore 1591
 }

--- a/src/Hangfire.Mongo.Tests/ExpirationManagerFacts.cs
+++ b/src/Hangfire.Mongo.Tests/ExpirationManagerFacts.cs
@@ -37,53 +37,53 @@ namespace Hangfire.Mongo.Tests
         [Fact, CleanDatabase]
         public void Execute_RemovesOutdatedRecords()
         {
-            using (var connection = ConnectionUtils.CreateConnection())
+            using (var database = ConnectionUtils.CreateConnection())
             {
-                CreateExpirationEntries(connection, DateTime.UtcNow.AddMonths(-1));
+                CreateExpirationEntries(database, DateTime.UtcNow.AddMonths(-1));
                 var manager = CreateManager();
 
                 manager.Execute(_token);
 
-                Assert.True(IsEntryExpired(connection));
+                Assert.True(IsEntryExpired(database));
             }
         }
 
         [Fact, CleanDatabase]
         public void Execute_DoesNotRemoveEntries_WithNoExpirationTimeSet()
         {
-            using (var connection = ConnectionUtils.CreateConnection())
+            using (var database = ConnectionUtils.CreateConnection())
             {
-                CreateExpirationEntries(connection, null);
+                CreateExpirationEntries(database, null);
                 var manager = CreateManager();
 
                 manager.Execute(_token);
 
-                Assert.False(IsEntryExpired(connection));
+                Assert.False(IsEntryExpired(database));
             }
         }
 
         [Fact, CleanDatabase]
         public void Execute_DoesNotRemoveEntries_WithFreshExpirationTime()
         {
-            using (var connection = ConnectionUtils.CreateConnection())
+            using (var database = ConnectionUtils.CreateConnection())
             {
-                CreateExpirationEntries(connection, DateTime.Now.AddMonths(1));
+                CreateExpirationEntries(database, DateTime.Now.AddMonths(1));
                 var manager = CreateManager();
 
                 manager.Execute(_token);
 
 
-                Assert.False(IsEntryExpired(connection));
+                Assert.False(IsEntryExpired(database));
             }
         }
 
         [Fact, CleanDatabase]
         public void Execute_Processes_CounterTable()
         {
-            using (var connection = ConnectionUtils.CreateConnection())
+            using (var database = ConnectionUtils.CreateConnection())
             {
                 // Arrange
-                connection.StateData.InsertOne(new CounterDto
+                database.StateData.InsertOne(new CounterDto
                 {
                     Id = ObjectId.GenerateNewId(),
                     Key = "key",
@@ -97,7 +97,7 @@ namespace Hangfire.Mongo.Tests
                 manager.Execute(_token);
 
                 // Assert
-                var count = connection.StateData.OfType<CounterDto>().Count(new BsonDocument());
+                var count = database.StateData.OfType<CounterDto>().Count(new BsonDocument());
                 Assert.Equal(0, count);
             }
         }
@@ -105,10 +105,10 @@ namespace Hangfire.Mongo.Tests
         [Fact, CleanDatabase]
         public void Execute_Processes_JobTable()
         {
-            using (var connection = ConnectionUtils.CreateConnection())
+            using (var database = ConnectionUtils.CreateConnection())
             {
                 // Arrange
-                connection.Job.InsertOne(new JobDto
+                database.Job.InsertOne(new JobDto
                 {
                     Id = 1.ToString(),
                     InvocationData = "",
@@ -123,7 +123,7 @@ namespace Hangfire.Mongo.Tests
                 manager.Execute(_token);
 
                 // Assert
-                var count = connection.Job.Count(new BsonDocument());
+                var count = database.Job.Count(new BsonDocument());
                 Assert.Equal(0, count);
             }
         }
@@ -131,10 +131,10 @@ namespace Hangfire.Mongo.Tests
         [Fact, CleanDatabase]
         public void Execute_Processes_ListTable()
         {
-            using (var connection = ConnectionUtils.CreateConnection())
+            using (var database = ConnectionUtils.CreateConnection())
             {
                 // Arrange
-                connection.StateData.InsertOne(new ListDto
+                database.StateData.InsertOne(new ListDto
                 {
                     Id = ObjectId.GenerateNewId(),
                     Key = "key",
@@ -147,7 +147,7 @@ namespace Hangfire.Mongo.Tests
                 manager.Execute(_token);
 
                 // Assert
-                var count = connection
+                var count = database
                     .StateData
                     .OfType<ListDto>()
                     .Count(new BsonDocument());
@@ -158,10 +158,10 @@ namespace Hangfire.Mongo.Tests
         [Fact, CleanDatabase]
         public void Execute_Processes_SetTable()
         {
-            using (var connection = ConnectionUtils.CreateConnection())
+            using (var database = ConnectionUtils.CreateConnection())
             {
                 // Arrange
-                connection.StateData.InsertOne(new SetDto
+                database.StateData.InsertOne(new SetDto
                 {
                     Id = ObjectId.GenerateNewId(),
                     Key = "key",
@@ -176,7 +176,7 @@ namespace Hangfire.Mongo.Tests
                 manager.Execute(_token);
 
                 // Assert
-                var count = connection
+                var count = database
                     .StateData
                     .OfType<SetDto>()
                     .Count(new BsonDocument());
@@ -187,10 +187,10 @@ namespace Hangfire.Mongo.Tests
         [Fact, CleanDatabase]
         public void Execute_Processes_HashTable()
         {
-            using (var connection = ConnectionUtils.CreateConnection())
+            using (var database = ConnectionUtils.CreateConnection())
             {
                 // Arrange
-                connection.StateData.InsertOne(new HashDto
+                database.StateData.InsertOne(new HashDto
                 {
                     Id = ObjectId.GenerateNewId(),
                     Key = "key",
@@ -205,7 +205,7 @@ namespace Hangfire.Mongo.Tests
                 manager.Execute(_token);
 
                 // Assert
-                var count = connection
+                var count = database
                     .StateData
                     .OfType<HashDto>()
                     .Count(new BsonDocument());
@@ -217,10 +217,10 @@ namespace Hangfire.Mongo.Tests
         [Fact, CleanDatabase]
         public void Execute_Processes_AggregatedCounterTable()
         {
-            using (var connection = ConnectionUtils.CreateConnection())
+            using (var database = ConnectionUtils.CreateConnection())
             {
                 // Arrange
-                connection.StateData.InsertOne(new AggregatedCounterDto
+                database.StateData.InsertOne(new AggregatedCounterDto
                 {
                     Key = "key",
                     Value = 1,
@@ -233,7 +233,7 @@ namespace Hangfire.Mongo.Tests
                 manager.Execute(_token);
 
                 // Assert
-                Assert.Equal(0, connection
+                Assert.Equal(0, database
                     .StateData
                     .OfType<CounterDto>()
                     .Find(new BsonDocument()).Count());
@@ -242,24 +242,24 @@ namespace Hangfire.Mongo.Tests
 
 
 
-        private static void CreateExpirationEntries(HangfireDbContext connection, DateTime? expireAt)
+        private static void CreateExpirationEntries(HangfireDbContext database, DateTime? expireAt)
         {
-            Commit(connection, x => x.AddToSet("my-key", "my-value"));
-            Commit(connection, x => x.AddToSet("my-key", "my-value1"));
-            Commit(connection, x => x.SetRangeInHash("my-hash-key", new[] { new KeyValuePair<string, string>("key", "value"), new KeyValuePair<string, string>("key1", "value1") }));
-            Commit(connection, x => x.AddRangeToSet("my-key", new[] { "my-value", "my-value1" }));
+            Commit(database, x => x.AddToSet("my-key", "my-value"));
+            Commit(database, x => x.AddToSet("my-key", "my-value1"));
+            Commit(database, x => x.SetRangeInHash("my-hash-key", new[] { new KeyValuePair<string, string>("key", "value"), new KeyValuePair<string, string>("key1", "value1") }));
+            Commit(database, x => x.AddRangeToSet("my-key", new[] { "my-value", "my-value1" }));
 
             if (expireAt.HasValue)
             {
                 var expireIn = expireAt.Value - DateTime.Now;
-                Commit(connection, x => x.ExpireHash("my-hash-key", expireIn));
-                Commit(connection, x => x.ExpireSet("my-key", expireIn));
+                Commit(database, x => x.ExpireHash("my-hash-key", expireIn));
+                Commit(database, x => x.ExpireSet("my-key", expireIn));
             }
         }
 
-        private static bool IsEntryExpired(HangfireDbContext connection)
+        private static bool IsEntryExpired(HangfireDbContext database)
         {
-            var count = connection
+            var count = database
                 .StateData
                 .OfType<ExpiringKeyValueDto>()
                 .Count(new BsonDocument());
@@ -272,9 +272,9 @@ namespace Hangfire.Mongo.Tests
             return new ExpirationManager(_storage);
         }
 
-        private static void Commit(HangfireDbContext connection, Action<MongoWriteOnlyTransaction> action)
+        private static void Commit(HangfireDbContext database, Action<MongoWriteOnlyTransaction> action)
         {
-            using (MongoWriteOnlyTransaction transaction = new MongoWriteOnlyTransaction(connection, _queueProviders, new MongoStorageOptions()))
+            using (MongoWriteOnlyTransaction transaction = new MongoWriteOnlyTransaction(database, _queueProviders, new MongoStorageOptions()))
             {
                 action(transaction);
                 transaction.Commit();

--- a/src/Hangfire.Mongo.Tests/Hangfire.Mongo.Tests.csproj
+++ b/src/Hangfire.Mongo.Tests/Hangfire.Mongo.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-		<TargetFrameworks>net46;netstandard1.5;netcoreapp1.0</TargetFrameworks>
-    <NoWarn>$(NoWarn);CS0618</NoWarn>
+    <TargetFrameworks>net46;netstandard1.5;netcoreapp1.0</TargetFrameworks>
+    <NoWarn>$(NoWarn);1591,CS0618</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>Hangfire.Mongo.Tests</AssemblyName>
     <PackageId>Hangfire.Mongo.Tests</PackageId>

--- a/src/Hangfire.Mongo.Tests/MongoConnectionFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoConnectionFacts.cs
@@ -44,7 +44,7 @@ namespace Hangfire.Mongo.Tests
             Assert.Equal("database", exception.ParamName);
         }
 
-        [Fact, CleanDatabase]
+        [Fact]
         public void Ctor_ThrowsAnException_WhenProvidersCollectionIsNull()
         {
             var exception = Assert.Throws<ArgumentNullException>(

--- a/src/Hangfire.Mongo.Tests/MongoConnectionFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoConnectionFacts.cs
@@ -39,7 +39,7 @@ namespace Hangfire.Mongo.Tests
         public void Ctor_ThrowsAnException_WhenConnectionIsNull()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new MongoConnection(null, _providers));
+                () => new MongoConnection(null, null));
 
             Assert.Equal("database", exception.ParamName);
         }

--- a/src/Hangfire.Mongo.Tests/MongoConnectionFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoConnectionFacts.cs
@@ -17,7 +17,6 @@ using Xunit;
 
 namespace Hangfire.Mongo.Tests
 {
-#pragma warning disable 1591
     [Collection("Database")]
     public class MongoConnectionFacts
     {
@@ -1596,5 +1595,4 @@ namespace Hangfire.Mongo.Tests
             Debug.WriteLine(arg);
         }
     }
-#pragma warning restore 1591
 }

--- a/src/Hangfire.Mongo.Tests/MongoDistributedLockFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoDistributedLockFacts.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Threading;
-using System.Threading.Tasks;
 using Hangfire.Mongo.Database;
 using Hangfire.Mongo.DistributedLock;
 using Hangfire.Mongo.Dto;
@@ -166,11 +165,12 @@ namespace Hangfire.Mongo.Tests
 
         private static void UseConnection(Action<HangfireDbContext> action)
         {
-            using (var connection = ConnectionUtils.CreateConnection())
+            using (var database = ConnectionUtils.CreateConnection())
             {
-                action(connection);
+                action(database);
             }
         }
+
     }
 #pragma warning restore 1591
 }

--- a/src/Hangfire.Mongo.Tests/MongoDistributedLockFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoDistributedLockFacts.cs
@@ -10,7 +10,6 @@ using Xunit;
 
 namespace Hangfire.Mongo.Tests
 {
-#pragma warning disable 1591
 
     [Collection("Database")]
     public class MongoDistributedLockFacts
@@ -172,5 +171,4 @@ namespace Hangfire.Mongo.Tests
         }
 
     }
-#pragma warning restore 1591
 }

--- a/src/Hangfire.Mongo.Tests/MongoDistributedLockFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoDistributedLockFacts.cs
@@ -14,6 +14,7 @@ namespace Hangfire.Mongo.Tests
     [Collection("Database")]
     public class MongoDistributedLockFacts
     {
+
         [Fact]
         public void Ctor_ThrowsAnException_WhenResourceIsNull()
         {
@@ -27,12 +28,51 @@ namespace Hangfire.Mongo.Tests
         }
 
         [Fact]
+        public void Ctor_ThrowsAnException_WhenResourceIsEmpty()
+        {
+            UseConnection(database =>
+            {
+                var exception = Assert.Throws<ArgumentException>(
+                    () => new MongoDistributedLock(string.Empty, TimeSpan.Zero, database, new MongoStorageOptions()));
+
+                Assert.Equal("resource", exception.ParamName);
+            });
+        }
+
+        [Fact]
+        public void Ctor_ThrowsAnException_WhenTimeoutIsToLong()
+        {
+            UseConnection(database =>
+            {
+                var exception = Assert.Throws<ArgumentException>(
+                    () => new MongoDistributedLock("resource1", TimeSpan.MaxValue, database, new MongoStorageOptions()));
+
+                Assert.Equal("timeout", exception.ParamName);
+            });
+        }
+
+        [Fact]
         public void Ctor_ThrowsAnException_WhenConnectionIsNull()
         {
-            var exception = Assert.Throws<ArgumentNullException>(
-                () => new MongoDistributedLock("resource1", TimeSpan.Zero, null, new MongoStorageOptions()));
+            UseConnection(database =>
+            {
+                var exception = Assert.Throws<ArgumentNullException>(
+                    () => new MongoDistributedLock("resource1", TimeSpan.Zero, null, new MongoStorageOptions()));
 
-            Assert.Equal("database", exception.ParamName);
+                Assert.Equal("database", exception.ParamName);
+            });
+        }
+
+        [Fact]
+        public void Ctor_ThrowsAnException_WhenStorageOptionsIsNull()
+        {
+            UseConnection(database =>
+            {
+                var exception = Assert.Throws<ArgumentNullException>(
+                    () => new MongoDistributedLock("resource1", TimeSpan.Zero, database, null));
+
+                Assert.Equal("storageOptions", exception.ParamName);
+            });
         }
 
         [Fact, CleanDatabase]
@@ -40,12 +80,10 @@ namespace Hangfire.Mongo.Tests
         {
             UseConnection(database =>
             {
-                using (
-                    new MongoDistributedLock("resource1", TimeSpan.Zero, database, new MongoStorageOptions()))
+                using (new MongoDistributedLock("resource1", TimeSpan.Zero, database, new MongoStorageOptions()))
                 {
-                    var locksCount =
-                        database.DistributedLock.Count(Builders<DistributedLockDto>.Filter.Eq(_ => _.Resource,
-                            "resource1"));
+                    var filter = Builders<DistributedLockDto>.Filter.Eq(_ => _.Resource, "resource1");
+                    var locksCount = database.DistributedLock.Count(filter);
                     Assert.Equal(1, locksCount);
                 }
             });
@@ -56,13 +94,14 @@ namespace Hangfire.Mongo.Tests
         {
             UseConnection(database =>
             {
+                var filter = Builders<DistributedLockDto>.Filter.Eq(_ => _.Resource, "resource1");
                 using (new MongoDistributedLock("resource1", TimeSpan.Zero, database, new MongoStorageOptions()))
                 {
-                    var locksCount = database.DistributedLock.Count(Builders<DistributedLockDto>.Filter.Eq(_ => _.Resource, "resource1"));
+                    var locksCount = database.DistributedLock.Count(filter);
                     Assert.Equal(1, locksCount);
                 }
 
-                var locksCountAfter = database.DistributedLock.Count(Builders<DistributedLockDto>.Filter.Eq(_ => _.Resource, "resource1"));
+                var locksCountAfter = database.DistributedLock.Count(filter);
                 Assert.Equal(0, locksCountAfter);
             });
         }
@@ -74,12 +113,13 @@ namespace Hangfire.Mongo.Tests
             {
                 using (new MongoDistributedLock("resource1", TimeSpan.Zero, database, new MongoStorageOptions()))
                 {
-                    var locksCount = database.DistributedLock.Count(Builders<DistributedLockDto>.Filter.Eq(_ => _.Resource, "resource1"));
+                    var filter = Builders<DistributedLockDto>.Filter.Eq(_ => _.Resource, "resource1");
+                    var locksCount = database.DistributedLock.Count(filter);
                     Assert.Equal(1, locksCount);
 
                     using (new MongoDistributedLock("resource1", TimeSpan.Zero, database, new MongoStorageOptions()))
                     {
-                        locksCount = database.DistributedLock.Count(Builders<DistributedLockDto>.Filter.Eq(_ => _.Resource, "resource1"));
+                        locksCount = database.DistributedLock.Count(filter);
                         Assert.Equal(1, locksCount);
                     }
                 }
@@ -93,7 +133,8 @@ namespace Hangfire.Mongo.Tests
             {
                 using (new MongoDistributedLock("resource1", TimeSpan.Zero, database, new MongoStorageOptions()))
                 {
-                    var locksCount = database.DistributedLock.Count(Builders<DistributedLockDto>.Filter.Eq(_ => _.Resource, "resource1"));
+                    var filter = Builders<DistributedLockDto>.Filter.Eq(_ => _.Resource, "resource1");
+                    var locksCount = database.DistributedLock.Count(filter);
                     Assert.Equal(1, locksCount);
 
                     var t = new Thread(() =>
@@ -107,7 +148,7 @@ namespace Hangfire.Mongo.Tests
             });
         }
 
-        [Fact, CleanDatabase]
+        [Fact, CleanDatabase, MongoSignal]
         public void Ctor_WaitForLock_SignaledAtLockRelease()
         {
             UseConnection(database =>
@@ -133,29 +174,22 @@ namespace Hangfire.Mongo.Tests
             });
         }
 
-        [Fact]
-        public void Ctor_ThrowsAnException_WhenOptionsIsNull()
-        {
-            UseConnection(database =>
-            {
-                var exception = Assert.Throws<ArgumentNullException>(() =>
-                    new MongoDistributedLock("resource1", TimeSpan.Zero, database, null));
-
-                Assert.Equal("storageOptions", exception.ParamName);
-            });
-        }
-
         [Fact, CleanDatabase]
         public void Ctor_SetLockExpireAtWorks_WhenResourceIsNotLocked()
         {
             UseConnection(database =>
             {
-                using (new MongoDistributedLock("resource1", TimeSpan.Zero, database, new MongoStorageOptions() { DistributedLockLifetime = TimeSpan.FromSeconds(3) }))
+                var storageOption = new MongoStorageOptions
+                {
+                    DistributedLockLifetime = TimeSpan.FromSeconds(3)
+                };
+                using (new MongoDistributedLock("resource1", TimeSpan.Zero, database, storageOption))
                 {
                     DateTime initialExpireAt = DateTime.UtcNow;
                     Thread.Sleep(TimeSpan.FromSeconds(5));
 
-                    DistributedLockDto lockEntry = database.DistributedLock.Find(Builders<DistributedLockDto>.Filter.Eq(_ => _.Resource, "resource1")).FirstOrDefault();
+                    var filter = Builders<DistributedLockDto>.Filter.Eq(_ => _.Resource, "resource1");
+                    DistributedLockDto lockEntry = database.DistributedLock.Find(filter).FirstOrDefault();
                     Assert.NotNull(lockEntry);
                     Assert.True(lockEntry.ExpireAt > initialExpireAt);
                 }

--- a/src/Hangfire.Mongo.Tests/MongoFetchedJobFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoFetchedJobFacts.cs
@@ -9,7 +9,6 @@ using Xunit;
 
 namespace Hangfire.Mongo.Tests
 {
-#pragma warning disable 1591
     [Collection("Database")]
     public class MongoFetchedJobFacts
     {
@@ -168,5 +167,4 @@ namespace Hangfire.Mongo.Tests
             }
         }
     }
-#pragma warning restore 1591
 }

--- a/src/Hangfire.Mongo.Tests/MongoFetchedJobFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoFetchedJobFacts.cs
@@ -20,21 +20,21 @@ namespace Hangfire.Mongo.Tests
         [Fact]
         public void Ctor_ThrowsAnException_WhenConnectionIsNull()
         {
-            UseConnection(connection =>
+            UseConnection(database =>
             {
                 var exception = Assert.Throws<ArgumentNullException>(
                     () => new MongoFetchedJob(null, ObjectId.GenerateNewId(), JobId, Queue));
 
-                Assert.Equal("connection", exception.ParamName);
+                Assert.Equal("database", exception.ParamName);
             });
         }
 
         [Fact]
         public void Ctor_ThrowsAnException_WhenJobIdIsNull()
         {
-            UseConnection(connection =>
+            UseConnection(database =>
             {
-                var exception = Assert.Throws<ArgumentNullException>(() => new MongoFetchedJob(connection, ObjectId.GenerateNewId(), null, Queue));
+                var exception = Assert.Throws<ArgumentNullException>(() => new MongoFetchedJob(database, ObjectId.GenerateNewId(), null, Queue));
 
                 Assert.Equal("jobId", exception.ParamName);
             });
@@ -43,10 +43,10 @@ namespace Hangfire.Mongo.Tests
         [Fact]
         public void Ctor_ThrowsAnException_WhenQueueIsNull()
         {
-            UseConnection(connection =>
+            UseConnection(database =>
             {
                 var exception = Assert.Throws<ArgumentNullException>(
-                    () => new MongoFetchedJob(connection, ObjectId.GenerateNewId(), JobId, null));
+                    () => new MongoFetchedJob(database, ObjectId.GenerateNewId(), JobId, null));
 
                 Assert.Equal("queue", exception.ParamName);
             });
@@ -55,9 +55,9 @@ namespace Hangfire.Mongo.Tests
         [Fact]
         public void Ctor_CorrectlySets_AllInstanceProperties()
         {
-            UseConnection(connection =>
+            UseConnection(database =>
             {
-                var fetchedJob = new MongoFetchedJob(connection, ObjectId.GenerateNewId(), JobId, Queue);
+                var fetchedJob = new MongoFetchedJob(database, ObjectId.GenerateNewId(), JobId, Queue);
 
                 Assert.Equal(JobId, fetchedJob.JobId);
                 Assert.Equal(Queue, fetchedJob.Queue);
@@ -67,19 +67,19 @@ namespace Hangfire.Mongo.Tests
         [Fact, CleanDatabase]
         public void RemoveFromQueue_ReallyDeletesTheJobFromTheQueue()
         {
-            UseConnection(connection =>
+            UseConnection(database =>
             {
                 // Arrange
                 var queue = "default";
                 var jobId = ObjectId.GenerateNewId().ToString();
-                var id = CreateJobQueueRecord(connection, jobId, queue);
-                var processingJob = new MongoFetchedJob(connection, id, jobId, queue);
+                var id = CreateJobQueueRecord(database, jobId, queue);
+                var processingJob = new MongoFetchedJob(database, id, jobId, queue);
 
                 // Act
                 processingJob.RemoveFromQueue();
 
                 // Assert
-                var count = connection.JobQueue.Count(new BsonDocument());
+                var count = database.JobQueue.Count(new BsonDocument());
                 Assert.Equal(0, count);
             });
         }
@@ -87,20 +87,20 @@ namespace Hangfire.Mongo.Tests
         [Fact, CleanDatabase]
         public void RemoveFromQueue_DoesNotDelete_UnrelatedJobs()
         {
-            UseConnection(connection =>
+            UseConnection(database =>
             {
                 // Arrange
-                CreateJobQueueRecord(connection, "1", "default");
-                CreateJobQueueRecord(connection, "2", "critical");
-                CreateJobQueueRecord(connection, "3", "default");
+                CreateJobQueueRecord(database, "1", "default");
+                CreateJobQueueRecord(database, "2", "critical");
+                CreateJobQueueRecord(database, "3", "default");
 
-                var fetchedJob = new MongoFetchedJob(connection, ObjectId.GenerateNewId(), "999", "default");
+                var fetchedJob = new MongoFetchedJob(database, ObjectId.GenerateNewId(), "999", "default");
 
                 // Act
                 fetchedJob.RemoveFromQueue();
 
                 // Assert
-                var count = connection.JobQueue.Count(new BsonDocument());
+                var count = database.JobQueue.Count(new BsonDocument());
                 Assert.Equal(3, count);
             });
         }
@@ -108,19 +108,19 @@ namespace Hangfire.Mongo.Tests
         [Fact, CleanDatabase]
         public void Requeue_SetsFetchedAtValueToNull()
         {
-            UseConnection(connection =>
+            UseConnection(database =>
             {
                 // Arrange
                 var queue = "default";
                 var jobId = ObjectId.GenerateNewId().ToString();
-                var id = CreateJobQueueRecord(connection, jobId, queue);
-                var processingJob = new MongoFetchedJob(connection, id, jobId, queue);
+                var id = CreateJobQueueRecord(database, jobId, queue);
+                var processingJob = new MongoFetchedJob(database, id, jobId, queue);
 
                 // Act
                 processingJob.Requeue();
 
                 // Assert
-                var record = connection.JobQueue.Find(new BsonDocument()).ToList().Single();
+                var record = database.JobQueue.Find(new BsonDocument()).ToList().Single();
                 Assert.Null(record.FetchedAt);
             });
         }
@@ -128,24 +128,24 @@ namespace Hangfire.Mongo.Tests
         [Fact, CleanDatabase]
         public void Dispose_SetsFetchedAtValueToNull_IfThereWereNoCallsToComplete()
         {
-            UseConnection(connection =>
+            UseConnection(database =>
             {
                 // Arrange
                 var queue = "default";
                 var jobId = ObjectId.GenerateNewId().ToString();
-                var id = CreateJobQueueRecord(connection, jobId, queue);
-                var processingJob = new MongoFetchedJob(connection, id, jobId, queue);
+                var id = CreateJobQueueRecord(database, jobId, queue);
+                var processingJob = new MongoFetchedJob(database, id, jobId, queue);
 
                 // Act
                 processingJob.Dispose();
 
                 // Assert
-                var record = connection.JobQueue.Find(new BsonDocument()).ToList().Single();
+                var record = database.JobQueue.Find(new BsonDocument()).ToList().Single();
                 Assert.Null(record.FetchedAt);
             });
         }
 
-        private static ObjectId CreateJobQueueRecord(HangfireDbContext connection, string jobId, string queue)
+        private static ObjectId CreateJobQueueRecord(HangfireDbContext database, string jobId, string queue)
         {
             var jobQueue = new JobQueueDto
             {
@@ -155,16 +155,16 @@ namespace Hangfire.Mongo.Tests
                 FetchedAt = DateTime.UtcNow
             };
 
-            connection.JobQueue.InsertOne(jobQueue);
+            database.JobQueue.InsertOne(jobQueue);
 
             return jobQueue.Id;
         }
 
         private static void UseConnection(Action<HangfireDbContext> action)
         {
-            using (var connection = ConnectionUtils.CreateConnection())
+            using (var database = ConnectionUtils.CreateConnection())
             {
-                action(connection);
+                action(database);
             }
         }
     }

--- a/src/Hangfire.Mongo.Tests/MongoJobQueueFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoJobQueueFacts.cs
@@ -21,7 +21,7 @@ namespace Hangfire.Mongo.Tests
         public void Ctor_ThrowsAnException_WhenConnectionIsNull()
         {
             var exception = Assert.Throws<ArgumentNullException>(() =>
-                new MongoJobQueue(null, new MongoStorageOptions()));
+                new MongoJobQueue(null, null));
 
             Assert.Equal("database", exception.ParamName);
         }
@@ -327,14 +327,13 @@ namespace Hangfire.Mongo.Tests
 
         private static CancellationToken CreateTimingOutCancellationToken()
         {
-            var source = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            var source = new CancellationTokenSource(TimeSpan.FromSeconds(5));
             return source.Token;
         }
 
         private static MongoJobQueue CreateJobQueue(HangfireDbContext database)
         {
-            var storageOptions = new MongoStorageOptions();
-            return new MongoJobQueue(database, storageOptions);
+            return new MongoJobQueue(database, new MongoStorageOptions());
         }
 
         private static void UseConnection(Action<HangfireDbContext> action)

--- a/src/Hangfire.Mongo.Tests/MongoJobQueueFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoJobQueueFacts.cs
@@ -70,12 +70,14 @@ namespace Hangfire.Mongo.Tests
         {
             UseConnection(database =>
             {
-                var cts = new CancellationTokenSource();
-                cts.Cancel();
-                var queue = CreateJobQueue(database);
+                using (var cts = new CancellationTokenSource())
+                {
+                    cts.Cancel();
+                    var queue = CreateJobQueue(database);
 
-                Assert.Throws<OperationCanceledException>(() =>
-                    queue.Dequeue(DefaultQueues, cts.Token));
+                    Assert.Throws<OperationCanceledException>(() =>
+                        queue.Dequeue(DefaultQueues, cts.Token));
+                }
             });
         }
 
@@ -84,11 +86,13 @@ namespace Hangfire.Mongo.Tests
         {
             UseConnection(database =>
             {
-                var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
-                var queue = CreateJobQueue(database);
+                using (var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200)))
+                {
+                    var queue = CreateJobQueue(database);
 
-                Assert.Throws<OperationCanceledException>(() =>
-                    queue.Dequeue(DefaultQueues, cts.Token));
+                    Assert.Throws<OperationCanceledException>(() =>
+                        queue.Dequeue(DefaultQueues, cts.Token));
+                }
             });
         }
 
@@ -326,8 +330,8 @@ namespace Hangfire.Mongo.Tests
 
         private static CancellationToken CreateTimingOutCancellationToken()
         {
-            var source = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-            return source.Token;
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            return cts.Token;
         }
 
         private static MongoJobQueue CreateJobQueue(HangfireDbContext database)

--- a/src/Hangfire.Mongo.Tests/MongoJobQueueFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoJobQueueFacts.cs
@@ -11,7 +11,6 @@ using Xunit;
 
 namespace Hangfire.Mongo.Tests
 {
-#pragma warning disable 1591
     [Collection("Database")]
     public class MongoJobQueueFacts
     {
@@ -344,5 +343,4 @@ namespace Hangfire.Mongo.Tests
             }
         }
     }
-#pragma warning restore 1591
 }

--- a/src/Hangfire.Mongo.Tests/MongoMonitoringApiFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoMonitoringApiFacts.cs
@@ -224,7 +224,7 @@ namespace Hangfire.Mongo.Tests
                 Assert.Empty(resultList);
             });
         }
-        
+
         [Fact, CleanDatabase]
         public void FetchedJobs_ReturnsFetchedJobsOnly_WhenMultipleJobsExistsInFetchedAndUnfetchedStates()
         {
@@ -267,7 +267,7 @@ namespace Hangfire.Mongo.Tests
                         }
                     };
                     var succeededState = jobDto.StateHistory[0];
-                    jobDto.StateHistory = new[] {processingState, succeededState};
+                    jobDto.StateHistory = new[] { processingState, succeededState };
                     return jobDto;
                 });
 
@@ -293,19 +293,19 @@ namespace Hangfire.Mongo.Tests
         {
             using (var database = ConnectionUtils.CreateConnection())
             {
-                var connection = new MongoMonitoringApi(database, _providers);
-                action(database, connection);
+                var monitoringApi = new MongoMonitoringApi(database, _providers);
+                action(database, monitoringApi);
             }
         }
 
         private JobDto CreateJobInState(HangfireDbContext database, string jobId, string stateName, Func<JobDto, JobDto> visitor = null)
         {
             var job = Job.FromExpression(() => SampleMethod("wrong"));
-            
+
             Dictionary<string, string> stateData;
             if (stateName == EnqueuedState.StateName)
             {
-                stateData = new Dictionary<string, string> {["EnqueuedAt"] = $"{DateTime.UtcNow:o}"};
+                stateData = new Dictionary<string, string> { ["EnqueuedAt"] = $"{DateTime.UtcNow:o}" };
             }
             else if (stateName == ProcessingState.StateName)
             {
@@ -335,7 +335,7 @@ namespace Hangfire.Mongo.Tests
                 Arguments = "[\"\\\"Arguments\\\"\"]",
                 StateName = stateName,
                 CreatedAt = DateTime.UtcNow,
-                StateHistory = new []{jobState}
+                StateHistory = new[] { jobState }
             };
             if (visitor != null)
             {

--- a/src/Hangfire.Mongo.Tests/MongoMonitoringApiFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoMonitoringApiFacts.cs
@@ -13,7 +13,6 @@ using Xunit;
 
 namespace Hangfire.Mongo.Tests
 {
-#pragma warning disable 1591
     [Collection("Database")]
     public class MongoMonitoringApiFacts
     {
@@ -360,5 +359,4 @@ namespace Hangfire.Mongo.Tests
             return jobDto;
         }
     }
-#pragma warning restore 1591
 }

--- a/src/Hangfire.Mongo.Tests/MongoStorageFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoStorageFacts.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace Hangfire.Mongo.Tests
 {
-#pragma warning disable 1591
     [Collection("Database")]
     public class MongoStorageFacts
     {
@@ -64,5 +63,4 @@ namespace Hangfire.Mongo.Tests
         }
 
     }
-#pragma warning restore 1591
 }

--- a/src/Hangfire.Mongo.Tests/MongoStorageOptionsFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoStorageOptionsFacts.cs
@@ -5,7 +5,6 @@ using Xunit;
 
 namespace Hangfire.Mongo.Tests
 {
-#pragma warning disable 1591
     [Collection("Database")]
     public class MongoStorageOptionsFacts
     {
@@ -63,5 +62,4 @@ namespace Hangfire.Mongo.Tests
             Assert.Equal(TimeSpan.FromSeconds(1), storageOptions.QueuePollInterval);
         }
     }
-#pragma warning restore 1591
 }

--- a/src/Hangfire.Mongo.Tests/MongoStorageOptionsFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoStorageOptionsFacts.cs
@@ -36,30 +36,5 @@ namespace Hangfire.Mongo.Tests
             Assert.Equal(3, result.Count());
         }
 
-        [Fact]
-        public void Set_QueuePollInterval_ShouldThrowAnException_WhenGivenIntervalIsEqualToZero()
-        {
-            var storageOptions = new MongoStorageOptions();
-            Assert.Throws<ArgumentException>(
-                () => storageOptions.QueuePollInterval = TimeSpan.Zero);
-        }
-
-        [Fact]
-        public void Set_QueuePollInterval_ShouldThrowAnException_WhenGivenIntervalIsNegative()
-        {
-            var storageOptions = new MongoStorageOptions();
-            Assert.Throws<ArgumentException>(
-                () => storageOptions.QueuePollInterval = TimeSpan.FromSeconds(-1));
-        }
-
-        [Fact]
-        public void Set_QueuePollInterval_SetsTheValue()
-        {
-            var storageOptions = new MongoStorageOptions
-            {
-                QueuePollInterval = TimeSpan.FromSeconds(1)
-            };
-            Assert.Equal(TimeSpan.FromSeconds(1), storageOptions.QueuePollInterval);
-        }
     }
 }

--- a/src/Hangfire.Mongo.Tests/MongoWriteOnlyTransactionFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoWriteOnlyTransactionFacts.cs
@@ -13,7 +13,6 @@ using Xunit;
 
 namespace Hangfire.Mongo.Tests
 {
-#pragma warning disable 1591
     [Collection("Database")]
     public class MongoWriteOnlyTransactionFacts
     {
@@ -151,9 +150,9 @@ namespace Hangfire.Mongo.Tests
 
                 var jobId = job.Id;
                 var anotherJobId = anotherJob.Id;
-	            var serializedData = new Dictionary<string, string> {{"Name", "Value"}};
+                var serializedData = new Dictionary<string, string> { { "Name", "Value" } };
 
-				var state = new Mock<IState>();
+                var state = new Mock<IState>();
                 state.Setup(x => x.Name).Returns("State");
                 state.Setup(x => x.Reason).Returns("Reason");
                 state.Setup(x => x.SerializeData()).Returns(serializedData);
@@ -169,7 +168,7 @@ namespace Hangfire.Mongo.Tests
                 Assert.Equal(0, anotherTestJob.StateHistory.Length);
 
                 var jobWithStates = database.Job.Find(new BsonDocument()).ToList().FirstOrDefault();
-                
+
                 var jobState = jobWithStates.StateHistory.Single();
                 Assert.Equal("State", jobState.Name);
                 Assert.Equal("Reason", jobState.Reason);
@@ -193,9 +192,9 @@ namespace Hangfire.Mongo.Tests
                 database.Job.InsertOne(job);
 
                 var jobId = job.Id;
-	            var serializedData = new Dictionary<string, string> {{"Name", "Value"}};
+                var serializedData = new Dictionary<string, string> { { "Name", "Value" } };
 
-				var state = new Mock<IState>();
+                var state = new Mock<IState>();
                 state.Setup(x => x.Name).Returns("State");
                 state.Setup(x => x.Reason).Returns("Reason");
                 state.Setup(x => x.SerializeData()).Returns(serializedData);
@@ -863,7 +862,7 @@ namespace Hangfire.Mongo.Tests
                 Commit(database, x => x.AddRangeToSet(set1Val1.Key, values));
 
                 var testSet1 = GetTestSet(database, set1Val1.Key);
-                var valuesToTest = new List<string>(values) {"value1", "value2"};
+                var valuesToTest = new List<string>(values) { "value1", "value2" };
 
                 Assert.NotNull(testSet1);
                 // verify all values are present in testSet1
@@ -939,5 +938,4 @@ namespace Hangfire.Mongo.Tests
             }
         }
     }
-#pragma warning restore 1591
 }

--- a/src/Hangfire.Mongo.Tests/MongoWriteOnlyTransactionFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoWriteOnlyTransactionFacts.cs
@@ -33,7 +33,7 @@ namespace Hangfire.Mongo.Tests
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() => new MongoWriteOnlyTransaction(null, _queueProviders, new MongoStorageOptions()));
 
-            Assert.Equal("connection", exception.ParamName);
+            Assert.Equal("database", exception.ParamName);
         }
 
         [Fact, CleanDatabase]
@@ -49,7 +49,7 @@ namespace Hangfire.Mongo.Tests
         {
             var exception = Assert.Throws<ArgumentNullException>(() => new MongoWriteOnlyTransaction(ConnectionUtils.CreateConnection(), _queueProviders, null));
 
-            Assert.Equal("options", exception.ParamName);
+            Assert.Equal("storageOptions", exception.ParamName);
         }
 
         [Fact, CleanDatabase]

--- a/src/Hangfire.Mongo.Tests/MultipleServersFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MultipleServersFacts.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace Hangfire.Mongo.Tests
 {
-#pragma warning disable 1591
     [Collection("Database")]
     public class MultipleServersFacts
     {
@@ -71,5 +70,4 @@ namespace Hangfire.Mongo.Tests
         }
 
     }
-#pragma warning restore 1591
 }

--- a/src/Hangfire.Mongo.Tests/MultipleServersFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MultipleServersFacts.cs
@@ -17,7 +17,7 @@ namespace Hangfire.Mongo.Tests
             const int workerCount = 20;
 
             var options = new BackgroundJobServerOptions[serverCount];
-            var storage = ConnectionUtils.CreateStorage(new MongoStorageOptions { QueuePollInterval = TimeSpan.FromSeconds(1) });
+            var storage = ConnectionUtils.CreateStorage(new MongoStorageOptions());
             var servers = new BackgroundJobServer[serverCount];
 
             var jobManagers = new RecurringJobManager[serverCount];

--- a/src/Hangfire.Mongo.Tests/PersistentJobQueue/Mongo/MongoJobQueueMonitoringApiFacts.cs
+++ b/src/Hangfire.Mongo.Tests/PersistentJobQueue/Mongo/MongoJobQueueMonitoringApiFacts.cs
@@ -20,15 +20,15 @@ namespace Hangfire.Mongo.Tests.PersistentJobQueue.Mongo
         {
             var exception = Assert.Throws<ArgumentNullException>(() => new MongoJobQueueMonitoringApi(null));
 
-            Assert.Equal("connection", exception.ParamName);
+            Assert.Equal("database", exception.ParamName);
         }
 
         [Fact, CleanDatabase]
         public void GetQueues_ShouldReturnEmpty_WhenNoQueuesExist()
         {
-            UseConnection(connection =>
+            UseConnection(database =>
             {
-                var mongoJobQueueMonitoringApi = CreateMongoJobQueueMonitoringApi(connection);
+                var mongoJobQueueMonitoringApi = CreateMongoJobQueueMonitoringApi(database);
 
                 var queues = mongoJobQueueMonitoringApi.GetQueues();
 
@@ -39,11 +39,11 @@ namespace Hangfire.Mongo.Tests.PersistentJobQueue.Mongo
         [Fact, CleanDatabase]
         public void GetQueues_ShouldReturnOneQueue_WhenOneQueueExists()
         {
-            UseConnection(connection =>
+            UseConnection(database =>
             {
-                var mongoJobQueueMonitoringApi = CreateMongoJobQueueMonitoringApi(connection);
+                var mongoJobQueueMonitoringApi = CreateMongoJobQueueMonitoringApi(database);
 
-                CreateJobQueueDto(connection, QueueName1, false);
+                CreateJobQueueDto(database, QueueName1, false);
 
                 var queues = mongoJobQueueMonitoringApi.GetQueues().ToList();
 
@@ -55,13 +55,13 @@ namespace Hangfire.Mongo.Tests.PersistentJobQueue.Mongo
         [Fact, CleanDatabase]
         public void GetQueues_ShouldReturnTwoUniqueQueues_WhenThreeNonUniqueQueuesExist()
         {
-            UseConnection(connection =>
+            UseConnection(database =>
             {
-                var mongoJobQueueMonitoringApi = CreateMongoJobQueueMonitoringApi(connection);
+                var mongoJobQueueMonitoringApi = CreateMongoJobQueueMonitoringApi(database);
 
-                CreateJobQueueDto(connection, QueueName1, false);
-                CreateJobQueueDto(connection, QueueName1, false);
-                CreateJobQueueDto(connection, QueueName2, false);
+                CreateJobQueueDto(database, QueueName1, false);
+                CreateJobQueueDto(database, QueueName1, false);
+                CreateJobQueueDto(database, QueueName2, false);
 
                 var queues = mongoJobQueueMonitoringApi.GetQueues().ToList();
 
@@ -74,9 +74,9 @@ namespace Hangfire.Mongo.Tests.PersistentJobQueue.Mongo
         [Fact, CleanDatabase]
         public void GetEnqueuedJobIds_ShouldReturnEmpty_WheNoQueuesExist()
         {
-            UseConnection(connection =>
+            UseConnection(database =>
             {
-                var mongoJobQueueMonitoringApi = CreateMongoJobQueueMonitoringApi(connection);
+                var mongoJobQueueMonitoringApi = CreateMongoJobQueueMonitoringApi(database);
 
                 var enqueuedJobIds = mongoJobQueueMonitoringApi.GetEnqueuedJobIds(QueueName1, 0, 10);
 
@@ -87,11 +87,11 @@ namespace Hangfire.Mongo.Tests.PersistentJobQueue.Mongo
         [Fact, CleanDatabase]
         public void GetEnqueuedJobIds_ShouldReturnEmpty_WhenOneJobWithAFetchedStateExists()
         {
-            UseConnection(connection =>
+            UseConnection(database =>
             {
-                var mongoJobQueueMonitoringApi = CreateMongoJobQueueMonitoringApi(connection);
+                var mongoJobQueueMonitoringApi = CreateMongoJobQueueMonitoringApi(database);
 
-                CreateJobQueueDto(connection, QueueName1, true);
+                CreateJobQueueDto(database, QueueName1, true);
 
                 var enqueuedJobIds = mongoJobQueueMonitoringApi.GetEnqueuedJobIds(QueueName1, 0, 10).ToList();
 
@@ -102,11 +102,11 @@ namespace Hangfire.Mongo.Tests.PersistentJobQueue.Mongo
         [Fact, CleanDatabase]
         public void GetEnqueuedJobIds_ShouldReturnOneJobId_WhenOneJobExists()
         {
-            UseConnection(connection =>
+            UseConnection(database =>
             {
-                var mongoJobQueueMonitoringApi = CreateMongoJobQueueMonitoringApi(connection);
+                var mongoJobQueueMonitoringApi = CreateMongoJobQueueMonitoringApi(database);
 
-                var jobQueueDto = CreateJobQueueDto(connection, QueueName1, false);
+                var jobQueueDto = CreateJobQueueDto(database, QueueName1, false);
 
                 var enqueuedJobIds = mongoJobQueueMonitoringApi.GetEnqueuedJobIds(QueueName1, 0, 10).ToList();
 
@@ -118,13 +118,13 @@ namespace Hangfire.Mongo.Tests.PersistentJobQueue.Mongo
         [Fact, CleanDatabase]
         public void GetEnqueuedJobIds_ShouldReturnThreeJobIds_WhenThreeJobsExists()
         {
-            UseConnection(connection =>
+            UseConnection(database =>
             {
-                var mongoJobQueueMonitoringApi = CreateMongoJobQueueMonitoringApi(connection);
+                var mongoJobQueueMonitoringApi = CreateMongoJobQueueMonitoringApi(database);
 
-                var jobQueueDto = CreateJobQueueDto(connection, QueueName1, false);
-                var jobQueueDto2 = CreateJobQueueDto(connection, QueueName1, false);
-                var jobQueueDto3 = CreateJobQueueDto(connection, QueueName1, false);
+                var jobQueueDto = CreateJobQueueDto(database, QueueName1, false);
+                var jobQueueDto2 = CreateJobQueueDto(database, QueueName1, false);
+                var jobQueueDto3 = CreateJobQueueDto(database, QueueName1, false);
 
                 var enqueuedJobIds = mongoJobQueueMonitoringApi.GetEnqueuedJobIds(QueueName1, 0, 10).ToList();
 
@@ -138,13 +138,13 @@ namespace Hangfire.Mongo.Tests.PersistentJobQueue.Mongo
         [Fact, CleanDatabase]
         public void GetEnqueuedJobIds_ShouldReturnTwoJobIds_WhenThreeJobsExistsButOnlyTwoInRequestedQueue()
         {
-            UseConnection(connection =>
+            UseConnection(database =>
             {
-                var mongoJobQueueMonitoringApi = CreateMongoJobQueueMonitoringApi(connection);
+                var mongoJobQueueMonitoringApi = CreateMongoJobQueueMonitoringApi(database);
 
-                var jobQueueDto = CreateJobQueueDto(connection, QueueName1, false);
-                var jobQueueDto2 = CreateJobQueueDto(connection, QueueName1, false);
-                CreateJobQueueDto(connection, QueueName2, false);
+                var jobQueueDto = CreateJobQueueDto(database, QueueName1, false);
+                var jobQueueDto2 = CreateJobQueueDto(database, QueueName1, false);
+                CreateJobQueueDto(database, QueueName2, false);
 
                 var enqueuedJobIds = mongoJobQueueMonitoringApi.GetEnqueuedJobIds(QueueName1, 0, 10).ToList();
 
@@ -157,13 +157,13 @@ namespace Hangfire.Mongo.Tests.PersistentJobQueue.Mongo
         [Fact, CleanDatabase]
         public void GetEnqueuedJobIds_ShouldReturnTwoJobIds_WhenThreeJobsExistsButLimitIsSet()
         {
-            UseConnection(connection =>
+            UseConnection(database =>
             {
-                var mongoJobQueueMonitoringApi = CreateMongoJobQueueMonitoringApi(connection);
+                var mongoJobQueueMonitoringApi = CreateMongoJobQueueMonitoringApi(database);
 
-                var jobQueueDto = CreateJobQueueDto(connection, QueueName1, false);
-                var jobQueueDto2 = CreateJobQueueDto(connection, QueueName1, false);
-                CreateJobQueueDto(connection, QueueName1, false);
+                var jobQueueDto = CreateJobQueueDto(database, QueueName1, false);
+                var jobQueueDto2 = CreateJobQueueDto(database, QueueName1, false);
+                CreateJobQueueDto(database, QueueName1, false);
 
                 var enqueuedJobIds = mongoJobQueueMonitoringApi.GetEnqueuedJobIds(QueueName1, 0, 2).ToList();
 
@@ -176,9 +176,9 @@ namespace Hangfire.Mongo.Tests.PersistentJobQueue.Mongo
         [Fact, CleanDatabase]
         public void GetFetchedJobIds_ShouldReturnEmpty_WheNoQueuesExist()
         {
-            UseConnection(connection =>
+            UseConnection(database =>
             {
-                var mongoJobQueueMonitoringApi = CreateMongoJobQueueMonitoringApi(connection);
+                var mongoJobQueueMonitoringApi = CreateMongoJobQueueMonitoringApi(database);
 
                 var enqueuedJobIds = mongoJobQueueMonitoringApi.GetFetchedJobIds(QueueName1, 0, 10);
 
@@ -189,11 +189,11 @@ namespace Hangfire.Mongo.Tests.PersistentJobQueue.Mongo
         [Fact, CleanDatabase]
         public void GetFetchedJobIds_ShouldReturnEmpty_WhenOneJobWithNonFetchedStateExists()
         {
-            UseConnection(connection =>
+            UseConnection(database =>
             {
-                var mongoJobQueueMonitoringApi = CreateMongoJobQueueMonitoringApi(connection);
+                var mongoJobQueueMonitoringApi = CreateMongoJobQueueMonitoringApi(database);
 
-                CreateJobQueueDto(connection, QueueName1, false);
+                CreateJobQueueDto(database, QueueName1, false);
 
                 var enqueuedJobIds = mongoJobQueueMonitoringApi.GetFetchedJobIds(QueueName1, 0, 10).ToList();
 
@@ -204,11 +204,11 @@ namespace Hangfire.Mongo.Tests.PersistentJobQueue.Mongo
         [Fact, CleanDatabase]
         public void GetFetchedJobIds_ShouldReturnOneJobId_WhenOneJobExists()
         {
-            UseConnection(connection =>
+            UseConnection(database =>
             {
-                var mongoJobQueueMonitoringApi = CreateMongoJobQueueMonitoringApi(connection);
+                var mongoJobQueueMonitoringApi = CreateMongoJobQueueMonitoringApi(database);
 
-                var jobQueueDto = CreateJobQueueDto(connection, QueueName1, true);
+                var jobQueueDto = CreateJobQueueDto(database, QueueName1, true);
 
                 var enqueuedJobIds = mongoJobQueueMonitoringApi.GetFetchedJobIds(QueueName1, 0, 10).ToList();
 
@@ -220,13 +220,13 @@ namespace Hangfire.Mongo.Tests.PersistentJobQueue.Mongo
         [Fact, CleanDatabase]
         public void GetFetchedJobIds_ShouldReturnThreeJobIds_WhenThreeJobsExists()
         {
-            UseConnection(connection =>
+            UseConnection(database =>
             {
-                var mongoJobQueueMonitoringApi = CreateMongoJobQueueMonitoringApi(connection);
+                var mongoJobQueueMonitoringApi = CreateMongoJobQueueMonitoringApi(database);
 
-                var jobQueueDto = CreateJobQueueDto(connection, QueueName1, true);
-                var jobQueueDto2 = CreateJobQueueDto(connection, QueueName1, true);
-                var jobQueueDto3 = CreateJobQueueDto(connection, QueueName1, true);
+                var jobQueueDto = CreateJobQueueDto(database, QueueName1, true);
+                var jobQueueDto2 = CreateJobQueueDto(database, QueueName1, true);
+                var jobQueueDto3 = CreateJobQueueDto(database, QueueName1, true);
 
                 var enqueuedJobIds = mongoJobQueueMonitoringApi.GetFetchedJobIds(QueueName1, 0, 10).ToList();
 
@@ -240,13 +240,13 @@ namespace Hangfire.Mongo.Tests.PersistentJobQueue.Mongo
         [Fact, CleanDatabase]
         public void GetFetchedJobIds_ShouldReturnTwoJobIds_WhenThreeJobsExistsButOnlyTwoInRequestedQueue()
         {
-            UseConnection(connection =>
+            UseConnection(database =>
             {
-                var mongoJobQueueMonitoringApi = CreateMongoJobQueueMonitoringApi(connection);
+                var mongoJobQueueMonitoringApi = CreateMongoJobQueueMonitoringApi(database);
 
-                var jobQueueDto = CreateJobQueueDto(connection, QueueName1, true);
-                var jobQueueDto2 = CreateJobQueueDto(connection, QueueName1, true);
-                CreateJobQueueDto(connection, QueueName2, true);
+                var jobQueueDto = CreateJobQueueDto(database, QueueName1, true);
+                var jobQueueDto2 = CreateJobQueueDto(database, QueueName1, true);
+                CreateJobQueueDto(database, QueueName2, true);
 
                 var enqueuedJobIds = mongoJobQueueMonitoringApi.GetFetchedJobIds(QueueName1, 0, 10).ToList();
 
@@ -259,13 +259,13 @@ namespace Hangfire.Mongo.Tests.PersistentJobQueue.Mongo
         [Fact, CleanDatabase]
         public void GetFetchedJobIds_ShouldReturnTwoJobIds_WhenThreeJobsExistsButLimitIsSet()
         {
-            UseConnection(connection =>
+            UseConnection(database =>
             {
-                var mongoJobQueueMonitoringApi = CreateMongoJobQueueMonitoringApi(connection);
+                var mongoJobQueueMonitoringApi = CreateMongoJobQueueMonitoringApi(database);
 
-                var jobQueueDto = CreateJobQueueDto(connection, QueueName1, true);
-                var jobQueueDto2 = CreateJobQueueDto(connection, QueueName1, true);
-                CreateJobQueueDto(connection, QueueName1, true);
+                var jobQueueDto = CreateJobQueueDto(database, QueueName1, true);
+                var jobQueueDto2 = CreateJobQueueDto(database, QueueName1, true);
+                CreateJobQueueDto(database, QueueName1, true);
 
                 var enqueuedJobIds = mongoJobQueueMonitoringApi.GetFetchedJobIds(QueueName1, 0, 2).ToList();
 
@@ -275,7 +275,7 @@ namespace Hangfire.Mongo.Tests.PersistentJobQueue.Mongo
             });
         }
 
-        private static JobQueueDto CreateJobQueueDto(HangfireDbContext connection, string queue, bool isFetched)
+        private static JobQueueDto CreateJobQueueDto(HangfireDbContext database, string queue, bool isFetched)
         {
             var job = new JobDto
             {
@@ -283,7 +283,7 @@ namespace Hangfire.Mongo.Tests.PersistentJobQueue.Mongo
                 StateHistory = new []{new StateDto()}
             };
 
-            connection.Job.InsertOne(job);
+            database.Job.InsertOne(job);
 
             var jobQueue = new JobQueueDto
             {
@@ -296,21 +296,21 @@ namespace Hangfire.Mongo.Tests.PersistentJobQueue.Mongo
                 jobQueue.FetchedAt = DateTime.UtcNow.AddDays(-1);
             }
 
-            connection.JobQueue.InsertOne(jobQueue);
+            database.JobQueue.InsertOne(jobQueue);
 
             return jobQueue;
         }
 
-        private static MongoJobQueueMonitoringApi CreateMongoJobQueueMonitoringApi(HangfireDbContext connection)
+        private static MongoJobQueueMonitoringApi CreateMongoJobQueueMonitoringApi(HangfireDbContext database)
         {
-            return new MongoJobQueueMonitoringApi(connection);
+            return new MongoJobQueueMonitoringApi(database);
         }
 
         private static void UseConnection(Action<HangfireDbContext> action)
         {
-            using (var connection = ConnectionUtils.CreateConnection())
+            using (var database = ConnectionUtils.CreateConnection())
             {
-                action(connection);
+                action(database);
             }
         }
     }

--- a/src/Hangfire.Mongo.Tests/PersistentJobQueue/Mongo/MongoJobQueueMonitoringApiFacts.cs
+++ b/src/Hangfire.Mongo.Tests/PersistentJobQueue/Mongo/MongoJobQueueMonitoringApiFacts.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace Hangfire.Mongo.Tests.PersistentJobQueue.Mongo
 {
-#pragma warning disable 1591
     [Collection("Database")]
     public class MongoJobQueueMonitoringApiFacts
     {
@@ -280,7 +279,7 @@ namespace Hangfire.Mongo.Tests.PersistentJobQueue.Mongo
             var job = new JobDto
             {
                 CreatedAt = DateTime.UtcNow,
-                StateHistory = new []{new StateDto()}
+                StateHistory = new[] { new StateDto() }
             };
 
             database.Job.InsertOne(job);
@@ -314,5 +313,4 @@ namespace Hangfire.Mongo.Tests.PersistentJobQueue.Mongo
             }
         }
     }
-#pragma warning restore 1591
 }

--- a/src/Hangfire.Mongo.Tests/Signal/Mongo/MongoSignalFacts.cs
+++ b/src/Hangfire.Mongo.Tests/Signal/Mongo/MongoSignalFacts.cs
@@ -17,7 +17,7 @@ namespace Hangfire.Mongo.Tests.Signal.Mongo
         {
             var exception = Assert.Throws<ArgumentNullException>(() => new MongoSignal(null));
 
-            Assert.Equal("signal", exception.ParamName);
+            Assert.Equal("signalCollection", exception.ParamName);
         }
 
         [Fact]

--- a/src/Hangfire.Mongo.Tests/Signal/Mongo/MongoSignalFacts.cs
+++ b/src/Hangfire.Mongo.Tests/Signal/Mongo/MongoSignalFacts.cs
@@ -1,0 +1,152 @@
+﻿using System;
+using System.Threading;
+using Hangfire.Mongo.Database;
+using Hangfire.Mongo.Signal.Mongo;
+using Hangfire.Mongo.Tests.Utils;
+using MongoDB.Driver;
+using Xunit;
+
+namespace Hangfire.Mongo.Tests.Signal.Mongo
+{
+    [Collection("Database")]
+    public class MongoSignalFacts
+    {
+
+        [Fact]
+        public void Ctor_ThrowsAnException_WhenConnectionIsNull()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(() => new MongoSignal(null));
+
+            Assert.Equal("signal", exception.ParamName);
+        }
+
+        [Fact]
+        public void Signal_ThrowsAnException_WhenNameIsNull()
+        {
+            UseConnection(connection =>
+            {
+                var exception = Assert.Throws<ArgumentNullException>(() =>
+                {
+                    var signal = new MongoSignal(connection.Signal);
+                    signal.Set(null);
+                });
+
+                Assert.Equal("name", exception.ParamName);
+            });
+        }
+
+        [Fact]
+        public void Signal_ThrowsAnException_WhenNameIsEmpty()
+        {
+            UseConnection(connection =>
+            {
+                var exception = Assert.Throws<ArgumentException>(() =>
+                {
+                    var signal = new MongoSignal(connection.Signal);
+                    signal.Set(string.Empty);
+                });
+
+                Assert.Equal("name", exception.ParamName);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void Signal_ShouleStore_Always()
+        {
+            UseConnection(connection =>
+            {
+                var signal = new MongoSignal(connection.Signal);
+                signal.Set("thename");
+
+                var signals = connection
+                    .Signal.Find(s => s.Signaled == true && s.Name == "thename")
+                        .ToList();
+
+                Assert.Equal(1, signals.Count);
+            });
+        }
+
+        [Fact]
+        public void Wait_ThrowsAnException_WhenNameIsNull()
+        {
+            UseConnection(connection =>
+            {
+                var exception = Assert.Throws<ArgumentNullException>(() =>
+                {
+                    var signal = new MongoSignal(connection.Signal);
+                    signal.Wait(null, TimeSpan.FromSeconds(5));
+                });
+
+                Assert.Equal("name", exception.ParamName);
+            });
+        }
+
+        [Fact]
+        public void Wait_ThrowsAnException_WhenNameIsEmpty()
+        {
+            UseConnection(connection =>
+            {
+                var exception = Assert.Throws<ArgumentException>(() =>
+                {
+                    var signal = new MongoSignal(connection.Signal);
+                    signal.Wait(string.Empty, TimeSpan.FromSeconds(5));
+                });
+
+                Assert.Equal("name", exception.ParamName);
+            });
+        }
+
+        [Fact]
+        public void Wait_ThrowsAnException_WhenNamesIsNull()
+        {
+            UseConnection(connection =>
+            {
+                var exception = Assert.Throws<ArgumentNullException>(() =>
+                {
+                    var signal = new MongoSignal(connection.Signal);
+                    signal.Wait((string[])null, default(CancellationToken));
+                });
+
+                Assert.Equal("names", exception.ParamName);
+            });
+        }
+
+        [Fact]
+        public void Wait_ThrowsAnException_WhenNamesIsZeroLength()
+        {
+            UseConnection(connection =>
+            {
+                var exception = Assert.Throws<ArgumentException>(() =>
+                {
+                    var signal = new MongoSignal(connection.Signal);
+                    signal.Wait(new string[0], default(CancellationToken));
+                });
+
+                Assert.Equal("names", exception.ParamName);
+            });
+        }
+
+        [Fact]
+        public void Wait_ThrowsAnException_WhenNamesContainsEmptyName()
+        {
+            UseConnection(connection =>
+            {
+                var exception = Assert.Throws<ArgumentException>(() =>
+                {
+                    var signal = new MongoSignal(connection.Signal);
+                    signal.Wait(new[] { "test", "" }, default(CancellationToken));
+                });
+
+                Assert.Equal("names", exception.ParamName);
+            });
+        }
+
+        private static void UseConnection(Action<HangfireDbContext> action)
+        {
+            using (var connection = ConnectionUtils.CreateConnection())
+            {
+                action(connection);
+            }
+        }
+    }
+}

--- a/src/Hangfire.Mongo.Tests/Utils/CleanDatabaseAttribute.cs
+++ b/src/Hangfire.Mongo.Tests/Utils/CleanDatabaseAttribute.cs
@@ -30,14 +30,11 @@ namespace Hangfire.Mongo.Tests.Utils
             {
                 try
                 {
-                    context.Init(new MongoStorageOptions());
-
                     context.DistributedLock.DeleteMany(new BsonDocument());
                     context.StateData.DeleteMany(new BsonDocument());
                     context.Job.DeleteMany(new BsonDocument());
                     context.JobQueue.DeleteMany(new BsonDocument());
                     context.Server.DeleteMany(new BsonDocument());
-
                 }
                 catch (MongoException ex)
                 {

--- a/src/Hangfire.Mongo.Tests/Utils/ConnectionUtils.cs
+++ b/src/Hangfire.Mongo.Tests/Utils/ConnectionUtils.cs
@@ -3,8 +3,7 @@ using Hangfire.Mongo.Database;
 
 namespace Hangfire.Mongo.Tests.Utils
 {
-#pragma warning disable 1591
-    public static class ConnectionUtils
+    internal static class ConnectionUtils
     {
         private const string DatabaseVariable = "Hangfire_Mongo_DatabaseName";
         private const string ConnectionStringTemplateVariable = "Hangfire_Mongo_ConnectionStringTemplate";
@@ -12,12 +11,12 @@ namespace Hangfire.Mongo.Tests.Utils
         private const string DefaultDatabaseName = @"Hangfire-Mongo-Tests";
         private const string DefaultConnectionStringTemplate = @"mongodb://localhost";
 
-        private static string GetDatabaseName()
+        internal static string GetDatabaseName()
         {
             return Environment.GetEnvironmentVariable(DatabaseVariable) ?? DefaultDatabaseName;
         }
 
-        private static string GetConnectionString()
+        internal static string GetConnectionString()
         {
             return string.Format(GetConnectionStringTemplate(), GetDatabaseName());
         }
@@ -50,5 +49,5 @@ namespace Hangfire.Mongo.Tests.Utils
             return CreateStorage().Connection;
         }
     }
-#pragma warning restore 1591
+
 }

--- a/src/Hangfire.Mongo.Tests/Utils/MongoSignalAttribute.cs
+++ b/src/Hangfire.Mongo.Tests/Utils/MongoSignalAttribute.cs
@@ -1,0 +1,67 @@
+﻿using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Hangfire.Mongo.Signal.Mongo;
+using Xunit.Sdk;
+
+namespace Hangfire.Mongo.Tests.Utils
+{
+    public class MongoSignalAttribute : BeforeAfterTestAttribute
+    {
+        private static long Count = 0;
+        private static readonly object GlobalLock = new object();
+
+        private MongoSignalManager _mongoSignalManager;
+        private CancellationTokenSource _cancellationTokenSource;
+
+        public override void Before(MethodInfo methodUnderTest)
+        {
+
+            lock (GlobalLock)
+            {
+                if (Count == 0)
+                {
+                    Count += 1;
+                    Start();
+                }
+            }
+        }
+
+        public override void After(MethodInfo methodUnderTest)
+        {
+            lock (GlobalLock)
+            {
+                Count -= 1;
+                if (Count == 0)
+                {
+                    Stop();
+                }
+            }
+        }
+
+        public void Start()
+        {
+            _cancellationTokenSource = new CancellationTokenSource();
+            Task.Run(() =>
+            {
+                var cancellationToken = _cancellationTokenSource.Token;
+                _mongoSignalManager = new MongoSignalManager(ConnectionUtils.CreateStorage());
+
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    _mongoSignalManager.Execute(cancellationToken);
+                }
+
+                _cancellationTokenSource.Dispose();
+                _cancellationTokenSource = null;
+                _mongoSignalManager = null;
+            });
+        }
+
+        public void Stop()
+        {
+            _cancellationTokenSource.Cancel();
+        }
+
+    }
+}

--- a/src/Hangfire.Mongo.Tests/Utils/MongoSignalAttribute.cs
+++ b/src/Hangfire.Mongo.Tests/Utils/MongoSignalAttribute.cs
@@ -11,7 +11,7 @@ namespace Hangfire.Mongo.Tests.Utils
         private static long Count = 0;
         private static readonly object GlobalLock = new object();
 
-        private MongoSignalManager _mongoSignalManager;
+        private MongoSignalBackgroundProcess _mongoSignalManager;
         private CancellationTokenSource _cancellationTokenSource;
 
         public override void Before(MethodInfo methodUnderTest)
@@ -37,6 +37,8 @@ namespace Hangfire.Mongo.Tests.Utils
                     Stop();
                 }
             }
+            _cancellationTokenSource.Dispose();
+            _cancellationTokenSource = null;
         }
 
         public void Start()
@@ -45,7 +47,8 @@ namespace Hangfire.Mongo.Tests.Utils
             Task.Run(() =>
             {
                 var cancellationToken = _cancellationTokenSource.Token;
-                _mongoSignalManager = new MongoSignalManager(ConnectionUtils.CreateStorage());
+                var signalCollection = ConnectionUtils.CreateStorage().Connection.Signal;
+                _mongoSignalManager = new MongoSignalBackgroundProcess(signalCollection);
 
                 while (!cancellationToken.IsCancellationRequested)
                 {

--- a/src/Hangfire.Mongo/CountersAggregator.cs
+++ b/src/Hangfire.Mongo/CountersAggregator.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Hangfire.Logging;
-using Hangfire.Mongo.Database;
 using Hangfire.Mongo.Dto;
 using Hangfire.Server;
 using MongoDB.Bson;
@@ -31,10 +29,7 @@ namespace Hangfire.Mongo
         /// <param name="interval">Checking interval</param>
         public CountersAggregator(MongoStorage storage, TimeSpan interval)
         {
-            if (storage == null)
-                throw new ArgumentNullException(nameof(storage));
-
-            _storage = storage;
+            _storage = storage ?? throw new ArgumentNullException(nameof(storage));
             _interval = interval;
         }
 
@@ -101,12 +96,12 @@ namespace Hangfire.Mongo
                             database
                                 .StateData
                                 .InsertOne(new AggregatedCounterDto
-                            {
-                                Id = ObjectId.GenerateNewId(),
-                                Key = item.Key,
-                                Value = item.Value,
-                                ExpireAt = item.ExpireAt
-                            });
+                                {
+                                    Id = ObjectId.GenerateNewId(),
+                                    Key = item.Key,
+                                    Value = item.Value,
+                                    ExpireAt = item.ExpireAt
+                                });
                         }
                     }
 

--- a/src/Hangfire.Mongo/Database/HangfireDbContext.cs
+++ b/src/Hangfire.Mongo/Database/HangfireDbContext.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Hangfire.Mongo.Dto;
-using Hangfire.Mongo.Migration;
 using MongoDB.Driver;
 
 namespace Hangfire.Mongo.Database
@@ -99,16 +98,6 @@ namespace Hangfire.Mongo.Database
         /// Reference to collection which contains servers information
         /// </summary>
         public IMongoCollection<ServerDto> Server => Database.GetCollection<ServerDto>(_prefix + ".server");
-
-        /// <summary>
-        /// Initializes intial collections schema for Hangfire
-        /// </summary>
-        public void Init(MongoStorageOptions storageOptions)
-        {
-            var migrationManager = new MongoMigrationManager(storageOptions);
-            migrationManager.Migrate(this);
-        }
-
 
         /// <summary>
         /// Disposes the object

--- a/src/Hangfire.Mongo/Database/HangfireDbContext.cs
+++ b/src/Hangfire.Mongo/Database/HangfireDbContext.cs
@@ -83,8 +83,7 @@ namespace Hangfire.Mongo.Database
         /// <summary>
         /// Reference to collection which contains jobs queues
         /// </summary>
-        public IMongoCollection<JobQueueDto> JobQueue =>
-            Database.GetCollection<JobQueueDto>(_prefix + ".jobQueue");
+        public IMongoCollection<JobQueueDto> JobQueue => Database.GetCollection<JobQueueDto>(_prefix + ".jobQueue");
 
         /// <summary>
         /// Reference to collection which contains schemas

--- a/src/Hangfire.Mongo/Database/HangfireDbContext.cs
+++ b/src/Hangfire.Mongo/Database/HangfireDbContext.cs
@@ -86,6 +86,11 @@ namespace Hangfire.Mongo.Database
         public IMongoCollection<JobQueueDto> JobQueue => Database.GetCollection<JobQueueDto>(_prefix + ".jobQueue");
 
         /// <summary>
+        /// Reference to collection which is used for signalling
+        /// </summary>
+        public IMongoCollection<SignalDto> Signal => Database.GetCollection<SignalDto>(_prefix + ".signal");
+
+        /// <summary>
         /// Reference to collection which contains schemas
         /// </summary>
         public IMongoCollection<SchemaDto> Schema => Database.GetCollection<SchemaDto>(_prefix + ".schema");

--- a/src/Hangfire.Mongo/DistributedLock/MongoDistributedLock.cs
+++ b/src/Hangfire.Mongo/DistributedLock/MongoDistributedLock.cs
@@ -133,8 +133,7 @@ namespace Hangfire.Mongo.DistributedLock
                     isLockAcquired = Acquire();
                     if (!isLockAcquired)
                     {
-                        var cts = new CancellationTokenSource(timeout);
-                        _signal.Wait($@"{nameof(MongoDistributedLock)}.{_resource}", cts.Token);
+                        _signal.Wait($@"{nameof(MongoDistributedLock)}.{_resource}", timeout);
                         now = DateTime.Now;
                     }
                 }

--- a/src/Hangfire.Mongo/DistributedLock/MongoDistributedLock.cs
+++ b/src/Hangfire.Mongo/DistributedLock/MongoDistributedLock.cs
@@ -28,7 +28,7 @@ namespace Hangfire.Mongo.DistributedLock
         private readonly HangfireDbContext _database;
 
         private readonly MongoStorageOptions _storageOptions;
-        private readonly ISignal _signal;
+        private readonly IPersistentSignal _signal;
         private Timer _heartbeatTimer;
 
         private bool _completed;

--- a/src/Hangfire.Mongo/DistributedLock/MongoDistributedLock.cs
+++ b/src/Hangfire.Mongo/DistributedLock/MongoDistributedLock.cs
@@ -4,6 +4,8 @@ using System.Threading;
 using Hangfire.Logging;
 using Hangfire.Mongo.Database;
 using Hangfire.Mongo.Dto;
+using Hangfire.Mongo.Signal;
+using Hangfire.Mongo.Signal.Mongo;
 using Hangfire.Storage;
 using MongoDB.Driver;
 
@@ -14,13 +16,6 @@ namespace Hangfire.Mongo.DistributedLock
     /// </summary>
     internal sealed class MongoDistributedLock : IDisposable
     {
-
-        // EventWaitHandle is not supported on UNIX systems
-        // https://github.com/dotnet/coreclr/pull/1387
-        // Instead of using a compiler directive, we catch the
-        // exception and handles it. This way, when EventWaitHandle
-        // becomes available on UNIX, we will start working.
-        private static bool _isEventWaitHandleSupported = true;
 
         private static readonly ILog Logger = LogProvider.For<MongoDistributedLock>();
 
@@ -33,15 +28,13 @@ namespace Hangfire.Mongo.DistributedLock
         private readonly HangfireDbContext _database;
 
         private readonly MongoStorageOptions _storageOptions;
-
-
+        private readonly ISignal _signal;
         private Timer _heartbeatTimer;
 
         private bool _completed;
 
         private readonly object _lockObject = new object();
 
-        private string EventWaitHandleName => $@"{GetType().FullName}.{_resource}";
 
         /// <summary>
         /// Creates MongoDB distributed lock
@@ -66,6 +59,8 @@ namespace Hangfire.Mongo.DistributedLock
             {
                 throw new ArgumentException($"The timeout specified is too large. Please supply a timeout equal to or less than {int.MaxValue} seconds", nameof(timeout));
             }
+
+            _signal = new MongoSignal(_database.Signal);
 
             if (!AcquiredLocks.Value.ContainsKey(_resource) || AcquiredLocks.Value[_resource] == 0)
             {
@@ -126,80 +121,65 @@ namespace Hangfire.Mongo.DistributedLock
 
         private void Acquire(TimeSpan timeout)
         {
+            var isLockAcquired = false;
+
             try
             {
-                // If result is null, then it means we acquired the lock
-                var isLockAcquired = false;
                 var now = DateTime.Now;
                 var lockTimeoutTime = now.Add(timeout);
 
                 while (!isLockAcquired && (lockTimeoutTime >= now))
                 {
-                    // Acquire the lock if it does not exist - Notice: ReturnDocument.Before
-                    var filter = Builders<DistributedLockDto>.Filter.Eq(_ => _.Resource, _resource);
-                    var update = Builders<DistributedLockDto>.Update.SetOnInsert(_ => _.ExpireAt, DateTime.UtcNow.Add(_storageOptions.DistributedLockLifetime));
-                    var options = new FindOneAndUpdateOptions<DistributedLockDto>
+                    isLockAcquired = Acquire();
+                    if (!isLockAcquired)
                     {
-                        IsUpsert = true,
-                        ReturnDocument = ReturnDocument.Before
-                    };
-                    var result = _database.DistributedLock.FindOneAndUpdate(filter, update, options);
-
-                    // If result is null, it means we acquired the lock
-                    if (result == null)
-                    {
-                        isLockAcquired = true;
-                    }
-                    else
-                    {
-                        EventWaitHandle eventWaitHandle = null;
-                        var waitTime = (int)timeout.TotalMilliseconds / 10;
-                        if (_isEventWaitHandleSupported)
-                        {
-                            try
-                            {
-                                // Wait on the event. This allows us to be "woken" up sooner rather than later.
-                                // We wait in chunks as we need to "wake-up" from time to time and poll mongo,
-                                // in case that the lock was acquired on another machine or instance.
-                                eventWaitHandle = new EventWaitHandle(false, EventResetMode.AutoReset, EventWaitHandleName);
-                                eventWaitHandle.WaitOne(waitTime);
-                            }
-                            catch (PlatformNotSupportedException)
-                            {
-                                // See _isEventWaitHandleSupported definition for more info.
-                                _isEventWaitHandleSupported = false;
-                                eventWaitHandle = null;
-                            }
-                        }
-                        if (eventWaitHandle == null)
-                        {
-                            // Sleep for a while and then check if the lock has been released.
-                            Thread.Sleep(waitTime);
-                        }
+                        var cts = new CancellationTokenSource(timeout);
+                        _signal.Wait($@"{nameof(MongoDistributedLock)}.{_resource}", cts.Token);
                         now = DateTime.Now;
                     }
                 }
-
-                if (!isLockAcquired)
-                {
-                    throw new DistributedLockTimeoutException($"Could not place a lock on the resource \'{_resource}\': The lock request timed out.");
-                }
             }
-            catch (DistributedLockTimeoutException)
+            catch (OperationCanceledException)
             {
-                throw;
+                // The signal wait timed out
             }
             catch (Exception ex)
             {
                 throw new MongoDistributedLockException($"Could not place a lock on the resource \'{_resource}\': Check inner exception for details.", ex);
             }
+
+            if (!isLockAcquired)
+            {
+                throw new DistributedLockTimeoutException(
+                    $"Could not place a lock on the resource \'{_resource}\': The lock request timed out.");
+            }
         }
 
+        /// <summary>
+        /// Acquires the lock if possible
+        /// </summary>
+        /// <returns>
+        /// True if lock is acquired else false
+        /// </returns>
+        private bool Acquire()
+        {
+            // Acquire the lock if it does not exist - Notice: ReturnDocument.Before
+            var filter = Builders<DistributedLockDto>.Filter.Eq(_ => _.Resource, _resource);
+            var update = Builders<DistributedLockDto>.Update.SetOnInsert(_ => _.ExpireAt, DateTime.UtcNow.Add(_storageOptions.DistributedLockLifetime));
+            var options = new FindOneAndUpdateOptions<DistributedLockDto>
+            {
+                IsUpsert = true,
+                ReturnDocument = ReturnDocument.Before
+            };
+            var result = _database.DistributedLock.FindOneAndUpdate(filter, update, options);
+
+            return result == null;
+        }
 
         /// <summary>
         /// Release the lock
         /// </summary>
-        /// <exception cref="MongoDistributedLockException"></exception>
+        /// <exception cref="MongoDistributedLockException">Thrown if releasing the lock fails</exception>
         private void Release()
         {
             try
@@ -208,21 +188,7 @@ namespace Hangfire.Mongo.DistributedLock
                 _database.DistributedLock.DeleteOne(
                     Builders<DistributedLockDto>.Filter.Eq(_ => _.Resource, _resource));
 
-                if (_isEventWaitHandleSupported)
-                {
-                    try
-                    {
-                        if (EventWaitHandle.TryOpenExisting(EventWaitHandleName, out EventWaitHandle eventWaitHandler))
-                        {
-                            eventWaitHandler.Set();
-                        }
-                    }
-                    catch (PlatformNotSupportedException)
-                    {
-                        // See _isEventWaitHandleSupported definition for more info.
-                        _isEventWaitHandleSupported = false;
-                    }
-                }
+                _signal.Set($@"{nameof(MongoDistributedLock)}.{_resource}");
             }
             catch (Exception ex)
             {
@@ -236,7 +202,7 @@ namespace Hangfire.Mongo.DistributedLock
             try
             {
                 // Delete expired locks
-                _database.DistributedLock.DeleteOne(
+                _database.DistributedLock.DeleteMany(
                     Builders<DistributedLockDto>.Filter.Eq(_ => _.Resource, _resource) &
                     Builders<DistributedLockDto>.Filter.Lt(_ => _.ExpireAt, DateTime.UtcNow));
             }

--- a/src/Hangfire.Mongo/Dto/JobDto.cs
+++ b/src/Hangfire.Mongo/Dto/JobDto.cs
@@ -10,7 +10,7 @@ namespace Hangfire.Mongo.Dto
     {
         [BsonId(IdGenerator = typeof(StringObjectIdGenerator))]
         public string Id { get; set; }
-        
+
         public string StateName { get; set; }
 
         public string InvocationData { get; set; }
@@ -24,6 +24,6 @@ namespace Hangfire.Mongo.Dto
         public DateTime CreatedAt { get; set; }
 
         public DateTime? ExpireAt { get; set; }
-    } 
+    }
 #pragma warning restore 1591
 }

--- a/src/Hangfire.Mongo/Dto/ListDto.cs
+++ b/src/Hangfire.Mongo/Dto/ListDto.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using MongoDB.Bson;
-using MongoDB.Bson.Serialization.Attributes;
-
-namespace Hangfire.Mongo.Dto
+﻿namespace Hangfire.Mongo.Dto
 {
 #pragma warning disable 1591
     public class ListDto : ExpiringKeyValueDto

--- a/src/Hangfire.Mongo/Dto/SignalDto.cs
+++ b/src/Hangfire.Mongo/Dto/SignalDto.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace Hangfire.Mongo.Dto
+{
+#pragma warning disable 1591
+    public class SignalDto
+    {
+        [BsonId]
+        public ObjectId Id { get; set; }
+
+        public bool Signaled { get; set; }
+
+        public string Name { get; set; }
+
+        public DateTime TimeStamp { get; set; }
+    }
+#pragma warning restore 1591
+}

--- a/src/Hangfire.Mongo/ExpirationManager.cs
+++ b/src/Hangfire.Mongo/ExpirationManager.cs
@@ -35,10 +35,7 @@ namespace Hangfire.Mongo
         /// <param name="checkInterval">Checking interval</param>
         public ExpirationManager(MongoStorage storage, TimeSpan checkInterval)
         {
-            if (storage == null)
-                throw new ArgumentNullException(nameof(storage));
-
-            _storage = storage;
+            _storage = storage ?? throw new ArgumentNullException(nameof(storage));
             _checkInterval = checkInterval;
         }
 

--- a/src/Hangfire.Mongo/Hangfire.Mongo.Tests.xml
+++ b/src/Hangfire.Mongo/Hangfire.Mongo.Tests.xml
@@ -6,22 +6,22 @@
     <members>
         <member name="T:Hangfire.Mongo.Database.HangfireDbContext">
             <summary>
-            Represents Mongo database context for Hangfire
+            Represents Mongo connection context for Hangfire
             </summary>
         </member>
         <member name="M:Hangfire.Mongo.Database.HangfireDbContext.#ctor(System.String,System.String,System.String)">
             <summary>
-            Constructs context with connection string and database name
+            Constructs context with connection string and connection name
             </summary>
-            <param name="connectionString">Connection string for Mongo database</param>
+            <param name="connectionString">Connection string for Mongo connection</param>
             <param name="databaseName">Database name</param>
             <param name="prefix">Collections prefix</param>
         </member>
         <member name="M:Hangfire.Mongo.Database.HangfireDbContext.#ctor(MongoDB.Driver.MongoDatabase)">
             <summary>
-            Constructs context with existing Mongo database connection
+            Constructs context with existing Mongo connection connection
             </summary>
-            <param name="database">Database connection</param>
+            <param name="connection">Database connection</param>
         </member>
         <member name="M:Hangfire.Mongo.Database.HangfireDbContext.Init">
             <summary>
@@ -30,7 +30,7 @@
         </member>
         <member name="P:Hangfire.Mongo.Database.HangfireDbContext.ConnectionId">
             <summary>
-            Mongo database connection identifier
+            Mongo connection connection identifier
             </summary>
         </member>
         <member name="P:Hangfire.Mongo.Database.HangfireDbContext.DistributedLock">
@@ -88,8 +88,8 @@
             Configure Hangfire to use MongoDB storage
             </summary>
             <param name="configuration">Configuration</param>
-            <param name="connectionString">Connection string for Mongo database, for example 'mongodb://username:passwordY@host:port'</param>
-            <param name="databaseName">Name of database at Mongo server</param>
+            <param name="connectionString">Connection string for Mongo connection, for example 'mongodb://username:passwordY@host:port'</param>
+            <param name="databaseName">Name of connection at Mongo server</param>
             <returns></returns>
         </member>
         <member name="M:Hangfire.Mongo.MongoBootstrapperConfigurationExtensions.UseMongoStorage(Hangfire.IBootstrapperConfiguration,System.String,System.String,Hangfire.Mongo.MongoStorageOptions)">
@@ -97,14 +97,14 @@
             Configure Hangfire to use MongoDB storage
             </summary>
             <param name="configuration">Configuration</param>
-            <param name="connectionString">Connection string for Mongo database, for example 'mongodb://username:passwordY@host:port'</param>
-            <param name="databaseName">Name of database at Mongo server</param>
+            <param name="connectionString">Connection string for Mongo connection, for example 'mongodb://username:passwordY@host:port'</param>
+            <param name="databaseName">Name of connection at Mongo server</param>
             <param name="options">Storage options</param>
             <returns></returns>
         </member>
         <member name="T:Hangfire.Mongo.MongoUtils.AutoIncrementIdGenerator">
             <summary>
-            Represents ID generator for Mongo database
+            Represents ID generator for Mongo connection
             </summary>
         </member>
         <member name="M:Hangfire.Mongo.MongoUtils.AutoIncrementIdGenerator.#ctor">
@@ -135,21 +135,21 @@
         </member>
         <member name="T:Hangfire.Mongo.MongoUtils.MongoExtensions">
             <summary>
-            Helper utilities to work with Mongo database
+            Helper utilities to work with Mongo connection
             </summary>
         </member>
         <member name="M:Hangfire.Mongo.MongoUtils.MongoExtensions.GetServerTimeUtc(MongoDB.Driver.MongoDatabase)">
             <summary>
             Retreives server time in UTC zone
             </summary>
-            <param name="database">Mongo database</param>
+            <param name="connection">Mongo connection</param>
             <returns>Server time</returns>
         </member>
         <member name="M:Hangfire.Mongo.MongoUtils.MongoExtensions.GetServerTimeUtc(Hangfire.Mongo.Database.HangfireDbContext)">
             <summary>
             Retreives server time in UTC zone
             </summary>
-            <param name="dbContext">Hangfire database context</param>
+            <param name="dbContext">Hangfire connection context</param>
             <returns>Server time</returns>
         </member>
     </members>

--- a/src/Hangfire.Mongo/Hangfire.Mongo.XML
+++ b/src/Hangfire.Mongo/Hangfire.Mongo.XML
@@ -6,22 +6,22 @@
     <members>
         <member name="T:Hangfire.Mongo.Database.HangfireDbContext">
             <summary>
-            Represents Mongo database context for Hangfire
+            Represents Mongo connection context for Hangfire
             </summary>
         </member>
         <member name="M:Hangfire.Mongo.Database.HangfireDbContext.#ctor(System.String,System.String,System.String)">
             <summary>
-            Constructs context with connection string and database name
+            Constructs context with connection string and connection name
             </summary>
-            <param name="connectionString">Connection string for Mongo database</param>
+            <param name="connectionString">Connection string for Mongo connection</param>
             <param name="databaseName">Database name</param>
             <param name="prefix">Collections prefix</param>
         </member>
         <member name="M:Hangfire.Mongo.Database.HangfireDbContext.#ctor(MongoDB.Driver.MongoDatabase)">
             <summary>
-            Constructs context with existing Mongo database connection
+            Constructs context with existing Mongo connection connection
             </summary>
-            <param name="database">Database connection</param>
+            <param name="connection">Database connection</param>
         </member>
         <member name="M:Hangfire.Mongo.Database.HangfireDbContext.Init">
             <summary>
@@ -30,7 +30,7 @@
         </member>
         <member name="P:Hangfire.Mongo.Database.HangfireDbContext.ConnectionId">
             <summary>
-            Mongo database connection identifier
+            Mongo connection connection identifier
             </summary>
         </member>
         <member name="P:Hangfire.Mongo.Database.HangfireDbContext.DistributedLock">
@@ -88,8 +88,8 @@
             Configure Hangfire to use MongoDB storage
             </summary>
             <param name="configuration">Configuration</param>
-            <param name="connectionString">Connection string for Mongo database, for example 'mongodb://username:passwordY@host:port'</param>
-            <param name="databaseName">Name of database at Mongo server</param>
+            <param name="connectionString">Connection string for Mongo connection, for example 'mongodb://username:passwordY@host:port'</param>
+            <param name="databaseName">Name of connection at Mongo server</param>
             <returns></returns>
         </member>
         <member name="M:Hangfire.Mongo.MongoBootstrapperConfigurationExtensions.UseMongoStorage(Hangfire.IBootstrapperConfiguration,System.String,System.String,Hangfire.Mongo.MongoStorageOptions)">
@@ -97,14 +97,14 @@
             Configure Hangfire to use MongoDB storage
             </summary>
             <param name="configuration">Configuration</param>
-            <param name="connectionString">Connection string for Mongo database, for example 'mongodb://username:passwordY@host:port'</param>
-            <param name="databaseName">Name of database at Mongo server</param>
+            <param name="connectionString">Connection string for Mongo connection, for example 'mongodb://username:passwordY@host:port'</param>
+            <param name="databaseName">Name of connection at Mongo server</param>
             <param name="options">Storage options</param>
             <returns></returns>
         </member>
         <member name="T:Hangfire.Mongo.MongoUtils.AutoIncrementIdGenerator">
             <summary>
-            Represents ID generator for Mongo database
+            Represents ID generator for Mongo connection
             </summary>
         </member>
         <member name="M:Hangfire.Mongo.MongoUtils.AutoIncrementIdGenerator.#ctor">
@@ -135,21 +135,21 @@
         </member>
         <member name="T:Hangfire.Mongo.MongoUtils.MongoExtensions">
             <summary>
-            Helper utilities to work with Mongo database
+            Helper utilities to work with Mongo connection
             </summary>
         </member>
         <member name="M:Hangfire.Mongo.MongoUtils.MongoExtensions.GetServerTimeUtc(MongoDB.Driver.MongoDatabase)">
             <summary>
             Retreives server time in UTC zone
             </summary>
-            <param name="database">Mongo database</param>
+            <param name="connection">Mongo connection</param>
             <returns>Server time</returns>
         </member>
         <member name="M:Hangfire.Mongo.MongoUtils.MongoExtensions.GetServerTimeUtc(Hangfire.Mongo.Database.HangfireDbContext)">
             <summary>
             Retreives server time in UTC zone
             </summary>
-            <param name="dbContext">Hangfire database context</param>
+            <param name="dbContext">Hangfire connection context</param>
             <returns>Server time</returns>
         </member>
     </members>

--- a/src/Hangfire.Mongo/Migration/MongoMigrationManager.cs
+++ b/src/Hangfire.Mongo/Migration/MongoMigrationManager.cs
@@ -21,7 +21,7 @@ namespace Hangfire.Mongo.Migration
 
         public MongoMigrationManager(MongoStorageOptions storageOptions)
         {
-            _storageOptions = storageOptions;
+            _storageOptions = storageOptions ?? throw new ArgumentNullException(nameof(storageOptions));
         }
 
         public void Migrate(HangfireDbContext dbContext)
@@ -32,7 +32,7 @@ namespace Hangfire.Mongo.Migration
                 if (currentSchema == null)
                 {
                     // We do not have a schema version yet
-                    // - assume an empty database and run full migrations
+                    // - assume an empty connection and run full migrations
                     var migrationRunner = new MongoMigrationRunner(dbContext, _storageOptions);
                     migrationRunner.Execute(MongoSchema.None, RequiredSchemaVersion);
                     return;
@@ -43,8 +43,8 @@ namespace Hangfire.Mongo.Migration
                 {
                     var assemblyName = GetType().GetTypeInfo().Assembly.GetName();
                     throw new InvalidOperationException(
-                        $"{Environment.NewLine}{assemblyName.Name} version: {assemblyName.Version}, uses a schema prior to the current database." +
-                        $"{Environment.NewLine}Backwards migration is not supported. Please resolve this manually (e.g. by droping the database)." +
+                        $"{Environment.NewLine}{assemblyName.Name} version: {assemblyName.Version}, uses a schema prior to the current connection." +
+                        $"{Environment.NewLine}Backwards migration is not supported. Please resolve this manually (e.g. by droping the connection)." +
                         $"{Environment.NewLine}Please see https://github.com/sergeyzwezdin/Hangfire.Mongo#migration for further information.");
                 }
 

--- a/src/Hangfire.Mongo/Migration/MongoSchema.cs
+++ b/src/Hangfire.Mongo/Migration/MongoSchema.cs
@@ -14,7 +14,7 @@ namespace Hangfire.Mongo.Migration
         Version5 = 5,
         Version6 = 6,
         Version7 = 7,
-        Version8 = 8,
+        Version9 = 9,
     }
 
 
@@ -83,7 +83,7 @@ namespace Hangfire.Mongo.Migration
 						prefix + ".stateData"
 					};
 
-				case MongoSchema.Version8:
+				case MongoSchema.Version9:
 					return new[] {
 						prefix + ".job",
 						prefix + ".jobQueue",

--- a/src/Hangfire.Mongo/Migration/MongoSchema.cs
+++ b/src/Hangfire.Mongo/Migration/MongoSchema.cs
@@ -14,6 +14,7 @@ namespace Hangfire.Mongo.Migration
         Version5 = 5,
         Version6 = 6,
         Version7 = 7,
+        Version8 = 8,
     }
 
 
@@ -72,17 +73,28 @@ namespace Hangfire.Mongo.Migration
                         prefix + ".statedata"
                     };
 
-                case MongoSchema.Version7:
-                    return new[] {
-                        prefix + ".job",
-                        prefix + ".jobQueue",
-                        prefix + ".locks",
-                        prefix + ".schema",
-                        prefix + ".server",
-                        prefix + ".stateData"
-                    };
+				case MongoSchema.Version7:
+					return new[] {
+						prefix + ".job",
+						prefix + ".jobQueue",
+						prefix + ".locks",
+						prefix + ".schema",
+						prefix + ".server",
+						prefix + ".stateData"
+					};
 
-                default:
+				case MongoSchema.Version8:
+					return new[] {
+						prefix + ".job",
+						prefix + ".jobQueue",
+						prefix + ".locks",
+						prefix + ".schema",
+						prefix + ".server",
+						prefix + ".signal",
+						prefix + ".stateData"
+					};
+
+				default:
                     throw new ArgumentException($@"Unknown schema: '{schema}'", nameof(schema));
             }
         }

--- a/src/Hangfire.Mongo/Migration/Steps/Version07/01_EnqueuedJobMigration.cs
+++ b/src/Hangfire.Mongo/Migration/Steps/Version07/01_EnqueuedJobMigration.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using MongoDB.Bson;
 using MongoDB.Driver;
 

--- a/src/Hangfire.Mongo/Migration/Steps/Version08/00_CreateSignalCollection.cs
+++ b/src/Hangfire.Mongo/Migration/Steps/Version08/00_CreateSignalCollection.cs
@@ -1,0 +1,39 @@
+﻿using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Hangfire.Mongo.Migration.Steps.Version08
+{
+    /// <summary>
+    /// Create signal capped collection
+    /// </summary>
+    internal class CreateSignalCollection : IMongoMigrationStep
+    {
+        public MongoSchema TargetSchema => MongoSchema.Version8;
+
+        public long Sequence => 0;
+
+        public bool Execute(IMongoDatabase database, MongoStorageOptions storageOptions, IMongoMigrationBag migrationBag)
+        {
+            var name = $@"{storageOptions.Prefix}.signal";
+
+            var createOptions = new CreateCollectionOptions
+            {
+                Capped = true,
+                MaxSize = 1000000,
+                MaxDocuments = 1000
+            };
+            database.CreateCollection(name, createOptions);
+
+            // We have to create one document to get the trailing curser working
+            var dummySignal = new BsonDocument
+            {
+                ["Signaled"] = "false",
+                ["Name"] = "dummy"
+            };
+
+            database.GetCollection<BsonDocument>(name).InsertOne(dummySignal);
+
+            return true;
+        }
+    }
+}

--- a/src/Hangfire.Mongo/Migration/Steps/Version09/00_CreateSignalCollection.cs
+++ b/src/Hangfire.Mongo/Migration/Steps/Version09/00_CreateSignalCollection.cs
@@ -8,7 +8,7 @@ namespace Hangfire.Mongo.Migration.Steps.Version08
     /// </summary>
     internal class CreateSignalCollection : IMongoMigrationStep
     {
-        public MongoSchema TargetSchema => MongoSchema.Version8;
+        public MongoSchema TargetSchema => MongoSchema.Version9;
 
         public long Sequence => 0;
 

--- a/src/Hangfire.Mongo/MongoConnection.cs
+++ b/src/Hangfire.Mongo/MongoConnection.cs
@@ -27,7 +27,6 @@ namespace Hangfire.Mongo
         /// Ctor using default storage options
         /// </summary>
         public MongoConnection(HangfireDbContext database, PersistentJobQueueProviderCollection queueProviders)
-
             : this(database, new MongoStorageOptions(), queueProviders)
         {
         }

--- a/src/Hangfire.Mongo/MongoConnection.cs
+++ b/src/Hangfire.Mongo/MongoConnection.cs
@@ -55,14 +55,16 @@ namespace Hangfire.Mongo
             return new MongoDistributedLock($"Hangfire:{resource}", timeout, Database, _storageOptions);
         }
 
-        public override string CreateExpiredJob(Job job, IDictionary<string, string> parameters, DateTime createdAt,
-            TimeSpan expireIn)
+        public override string CreateExpiredJob(Job job, IDictionary<string, string> parameters, DateTime createdAt, TimeSpan expireIn)
         {
             if (job == null)
+            {
                 throw new ArgumentNullException(nameof(job));
-
+            }
             if (parameters == null)
+            {
                 throw new ArgumentNullException(nameof(parameters));
+            }
 
             var invocationData = InvocationData.Serialize(job);
 
@@ -85,7 +87,9 @@ namespace Hangfire.Mongo
         public override IFetchedJob FetchNextJob(string[] queues, CancellationToken cancellationToken)
         {
             if (queues == null || queues.Length == 0)
+            {
                 throw new ArgumentNullException(nameof(queues));
+            }
 
             var providers = queues
                 .Select(queue => _queueProviders.GetProvider(queue))
@@ -502,7 +506,7 @@ namespace Hangfire.Mongo
                 .SortBy(_ => _.ExpireAt)
                 .Project(_ => _.ExpireAt)
                 .FirstOrDefault();
-                
+
             return result.HasValue ? result.Value - DateTime.UtcNow : TimeSpan.FromSeconds(-1);
         }
 

--- a/src/Hangfire.Mongo/MongoFetchedJob.cs
+++ b/src/Hangfire.Mongo/MongoFetchedJob.cs
@@ -12,7 +12,7 @@ namespace Hangfire.Mongo
     /// </summary>
     public sealed class MongoFetchedJob : IFetchedJob
     {
-        private readonly HangfireDbContext _connection;
+        private readonly HangfireDbContext _database;
         private readonly ObjectId _id;
 
         private bool _disposed;
@@ -24,13 +24,13 @@ namespace Hangfire.Mongo
         /// <summary>
         /// Constructs fetched job by database connection, identifier, job ID and queue
         /// </summary>
-        /// <param name="connection">Database connection</param>
+        /// <param name="database">Database connection</param>
         /// <param name="id">Identifier</param>
         /// <param name="jobId">Job ID</param>
         /// <param name="queue">Queue name</param>
-        public MongoFetchedJob(HangfireDbContext connection, ObjectId id, string jobId, string queue)
+        public MongoFetchedJob(HangfireDbContext database, ObjectId id, string jobId, string queue)
         {
-            _connection = connection ?? throw new ArgumentNullException(nameof(connection));
+            _database = database ?? throw new ArgumentNullException(nameof(database));
             _id = id;
             JobId = jobId ?? throw new ArgumentNullException(nameof(jobId));
             Queue = queue ?? throw new ArgumentNullException(nameof(queue));
@@ -51,7 +51,7 @@ namespace Hangfire.Mongo
         /// </summary>
         public void RemoveFromQueue()
         {
-            _connection
+            _database
                .JobQueue
                .DeleteOne(Builders<JobQueueDto>.Filter.Eq(_ => _.Id, _id));
 
@@ -63,7 +63,7 @@ namespace Hangfire.Mongo
         /// </summary>
         public void Requeue()
         {
-            _connection.JobQueue.FindOneAndUpdate(
+            _database.JobQueue.FindOneAndUpdate(
                 Builders<JobQueueDto>.Filter.Eq(_ => _.Id, _id),
                 Builders<JobQueueDto>.Update.Set(_ => _.FetchedAt, null));
 

--- a/src/Hangfire.Mongo/MongoMigrationOptions.cs
+++ b/src/Hangfire.Mongo/MongoMigrationOptions.cs
@@ -71,5 +71,5 @@
         /// {collection-name}.{schema-version}.{BackupPostfix}
         /// </remarks>
         public string BackupPostfix { get; set; }
-    }         
+    }
 }

--- a/src/Hangfire.Mongo/MongoStorage.cs
+++ b/src/Hangfire.Mongo/MongoStorage.cs
@@ -141,7 +141,7 @@ namespace Hangfire.Mongo
         /// <returns>Collection of server components</returns>
         public override IEnumerable<IServerComponent> GetComponents()
         {
-            yield return new MongoSignalManager(this);
+            yield return new MongoSignalBackgroundProcess(this.Connection.Signal);
             yield return new ExpirationManager(this, _storageOptions.JobExpirationCheckInterval);
             yield return new CountersAggregator(this, _storageOptions.CountersAggregateInterval);
         }

--- a/src/Hangfire.Mongo/MongoStorage.cs
+++ b/src/Hangfire.Mongo/MongoStorage.cs
@@ -55,14 +55,10 @@ namespace Hangfire.Mongo
             {
                 throw new ArgumentNullException(nameof(databaseName));
             }
-            if (storageOptions == null)
-            {
-                throw new ArgumentNullException(nameof(storageOptions));
-            }
 
             _connectionString = connectionString;
             _databaseName = databaseName;
-            _storageOptions = storageOptions;
+            _storageOptions = storageOptions ?? throw new ArgumentNullException(nameof(storageOptions));
 
             Connection = new HangfireDbContext(connectionString, databaseName, storageOptions.Prefix);
             Connection.Init(_storageOptions);

--- a/src/Hangfire.Mongo/MongoStorage.cs
+++ b/src/Hangfire.Mongo/MongoStorage.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using Hangfire.Logging;
 using Hangfire.Mongo.Database;
+using Hangfire.Mongo.Migration;
 using Hangfire.Mongo.PersistentJobQueue;
 using Hangfire.Mongo.PersistentJobQueue.Mongo;
 using Hangfire.Mongo.Signal;
@@ -65,10 +66,13 @@ namespace Hangfire.Mongo
             _storageOptions = storageOptions ?? throw new ArgumentNullException(nameof(storageOptions));
 
             Connection = new HangfireDbContext(connectionString, databaseName, storageOptions.Prefix);
-            Connection.Init(_storageOptions);
-            var defaultQueueProvider = new MongoJobQueueProvider(_storageOptions);
+
             Signal = new MongoSignal(Connection.Signal);
 
+            var migrationManager = new MongoMigrationManager(storageOptions);
+            migrationManager.Migrate(Connection);
+
+            var defaultQueueProvider = new MongoJobQueueProvider(_storageOptions);
             QueueProviders = new PersistentJobQueueProviderCollection(defaultQueueProvider);
         }
 

--- a/src/Hangfire.Mongo/MongoStorageOptions.cs
+++ b/src/Hangfire.Mongo/MongoStorageOptions.cs
@@ -7,8 +7,6 @@ namespace Hangfire.Mongo
     /// </summary>
     public class MongoStorageOptions
     {
-        private TimeSpan _queuePollInterval;
-
         private TimeSpan _distributedLockLifetime;
 
         /// <summary>
@@ -17,7 +15,6 @@ namespace Hangfire.Mongo
         public MongoStorageOptions()
         {
             Prefix = "hangfire";
-            QueuePollInterval = TimeSpan.FromSeconds(15);
             InvisibilityTimeout = TimeSpan.FromMinutes(30);
             DistributedLockLifetime = TimeSpan.FromSeconds(30);
             JobExpirationCheckInterval = TimeSpan.FromHours(1);
@@ -36,25 +33,8 @@ namespace Hangfire.Mongo
         /// <summary>
         /// Poll interval for queue
         /// </summary>
-        public TimeSpan QueuePollInterval
-        {
-            get { return _queuePollInterval; }
-            set
-            {
-                var message = $"The QueuePollInterval property value should be positive. Given: {value}.";
-
-                if (value == TimeSpan.Zero)
-                {
-                    throw new ArgumentException(message, nameof(value));
-                }
-                if (value != value.Duration())
-                {
-                    throw new ArgumentException(message, nameof(value));
-                }
-
-                _queuePollInterval = value;
-            }
-        }
+        [Obsolete("This is not used as we do not use polling anymore")]
+        public TimeSpan QueuePollInterval { get; set; }
 
         /// <summary>
         /// Invisibility timeout

--- a/src/Hangfire.Mongo/MongoWriteOnlyTransaction.cs
+++ b/src/Hangfire.Mongo/MongoWriteOnlyTransaction.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Hangfire.Mongo.Database;
-using Hangfire.Mongo.DistributedLock;
 using Hangfire.Mongo.Dto;
 using Hangfire.Mongo.PersistentJobQueue;
 using Hangfire.States;
@@ -18,27 +17,18 @@ namespace Hangfire.Mongo
     {
         private readonly Queue<Action<HangfireDbContext>> _commandQueue = new Queue<Action<HangfireDbContext>>();
 
-        private readonly HangfireDbContext _connection;
+        private readonly HangfireDbContext _database;
 
         private readonly PersistentJobQueueProviderCollection _queueProviders;
 
-        private readonly MongoStorageOptions _options;
+        private readonly MongoStorageOptions _storageOptions;
 
-        public MongoWriteOnlyTransaction(HangfireDbContext connection,
-            PersistentJobQueueProviderCollection queueProviders, MongoStorageOptions options)
+        public MongoWriteOnlyTransaction(HangfireDbContext database,
+            PersistentJobQueueProviderCollection queueProviders, MongoStorageOptions storageOptions)
         {
-            if (connection == null)
-                throw new ArgumentNullException(nameof(connection));
-
-            if (queueProviders == null)
-                throw new ArgumentNullException(nameof(queueProviders));
-
-            if (options == null)
-                throw new ArgumentNullException(nameof(options));
-
-            _connection = connection;
-            _queueProviders = queueProviders;
-            _options = options;
+            _database = database ?? throw new ArgumentNullException(nameof(database));
+            _queueProviders = queueProviders ?? throw new ArgumentNullException(nameof(queueProviders));
+            _storageOptions = storageOptions ?? throw new ArgumentNullException(nameof(storageOptions));
         }
 
         public override void Dispose()
@@ -96,7 +86,7 @@ namespace Hangfire.Mongo
         public override void AddToQueue(string queue, string jobId)
         {
             IPersistentJobQueueProvider provider = _queueProviders.GetProvider(queue);
-            IPersistentJobQueue persistentQueue = provider.GetJobQueue(_connection);
+            IPersistentJobQueue persistentQueue = provider.GetJobQueue(_database);
 
             QueueCommand(_ =>
             {
@@ -269,7 +259,7 @@ namespace Hangfire.Mongo
         {
             foreach (var action in _commandQueue)
             {
-                action.Invoke(_connection);
+                action.Invoke(_database);
             }
         }
 

--- a/src/Hangfire.Mongo/PersistentJobQueue/IPersistentJobQueueProvider.cs
+++ b/src/Hangfire.Mongo/PersistentJobQueue/IPersistentJobQueueProvider.cs
@@ -5,9 +5,9 @@ namespace Hangfire.Mongo.PersistentJobQueue
 #pragma warning disable 1591
     public interface IPersistentJobQueueProvider
     {
-        IPersistentJobQueue GetJobQueue(HangfireDbContext connection);
+        IPersistentJobQueue GetJobQueue(HangfireDbContext database);
 
-        IPersistentJobQueueMonitoringApi GetJobQueueMonitoringApi(HangfireDbContext connection);
+        IPersistentJobQueueMonitoringApi GetJobQueueMonitoringApi(HangfireDbContext database);
     }
 #pragma warning restore 1591
 }

--- a/src/Hangfire.Mongo/PersistentJobQueue/Mongo/MongoJobQueue.cs
+++ b/src/Hangfire.Mongo/PersistentJobQueue/Mongo/MongoJobQueue.cs
@@ -17,7 +17,7 @@ namespace Hangfire.Mongo.PersistentJobQueue.Mongo
         private readonly HangfireDbContext _database;
 
         private readonly MongoStorageOptions _storageOptions;
-        private readonly ISignal _signal;
+        private readonly IPersistentSignal _signal;
 
         public MongoJobQueue(HangfireDbContext database, MongoStorageOptions storageOptions)
         {

--- a/src/Hangfire.Mongo/PersistentJobQueue/Mongo/MongoJobQueueProvider.cs
+++ b/src/Hangfire.Mongo/PersistentJobQueue/Mongo/MongoJobQueueProvider.cs
@@ -10,22 +10,17 @@ namespace Hangfire.Mongo.PersistentJobQueue.Mongo
 
         public MongoJobQueueProvider(MongoStorageOptions storageOptions)
         {
-            if (storageOptions == null)
-            {
-                throw new ArgumentNullException(nameof(storageOptions));
-            }
-
-            _storageOptions = storageOptions;
+            _storageOptions = storageOptions ?? throw new ArgumentNullException(nameof(storageOptions));
         }
 
-        public IPersistentJobQueue GetJobQueue(HangfireDbContext connection)
+        public IPersistentJobQueue GetJobQueue(HangfireDbContext database)
         {
-            return new MongoJobQueue(connection, _storageOptions);
+            return new MongoJobQueue(database, _storageOptions);
         }
 
-        public IPersistentJobQueueMonitoringApi GetJobQueueMonitoringApi(HangfireDbContext connection)
+        public IPersistentJobQueueMonitoringApi GetJobQueueMonitoringApi(HangfireDbContext database)
         {
-            return new MongoJobQueueMonitoringApi(connection);
+            return new MongoJobQueueMonitoringApi(database);
         }
     }
 #pragma warning restore 1591

--- a/src/Hangfire.Mongo/PersistentJobQueue/PersistentJobQueueProviderCollection.cs
+++ b/src/Hangfire.Mongo/PersistentJobQueue/PersistentJobQueueProviderCollection.cs
@@ -15,9 +15,7 @@ namespace Hangfire.Mongo.PersistentJobQueue
 
         public PersistentJobQueueProviderCollection(IPersistentJobQueueProvider defaultProvider)
         {
-            if (defaultProvider == null) throw new ArgumentNullException(nameof(defaultProvider));
-
-            _defaultProvider = defaultProvider;
+            _defaultProvider = defaultProvider ?? throw new ArgumentNullException(nameof(defaultProvider));
 
             _providers.Add(_defaultProvider);
         }
@@ -29,7 +27,7 @@ namespace Hangfire.Mongo.PersistentJobQueue
             if (queues == null)
                 throw new ArgumentNullException(nameof(queues));
 
-            _providers.Add(provider);
+            _providers.Add(provider ?? throw new ArgumentNullException(nameof(provider)));
 
             foreach (var queue in queues)
             {

--- a/src/Hangfire.Mongo/Signal/IPersistentSignal.cs
+++ b/src/Hangfire.Mongo/Signal/IPersistentSignal.cs
@@ -6,13 +6,15 @@ namespace Hangfire.Mongo.Signal
     /// <summary>
     /// 
     /// </summary>
-    public interface ISignal
+    public interface IPersistentSignal
     {
 
         /// <summary>
-        /// 
+        /// Sets the signal
         /// </summary>
-        /// <param name="name"></param>
+        /// <param name="name">
+        /// Name of the signal to set.
+        /// </param>
         void Set(string name);
 
         /// <summary>

--- a/src/Hangfire.Mongo/Signal/ISignal.cs
+++ b/src/Hangfire.Mongo/Signal/ISignal.cs
@@ -21,10 +21,19 @@ namespace Hangfire.Mongo.Signal
         /// <param name="name">
         /// Name of the signal to wait for.
         /// </param>
+        void Wait(string name);
+
+        /// <summary>
+        /// Wait for a signal with name.
+        /// </summary>
+        /// <param name="name">
+        /// Name of the signal to wait for.
+        /// </param>
         /// <param name="timeout">
         /// The timeout for the wait.
         /// </param>
         void Wait(string name, TimeSpan timeout);
+
 
         /// <summary>
         /// Wait for a signal with name.

--- a/src/Hangfire.Mongo/Signal/ISignal.cs
+++ b/src/Hangfire.Mongo/Signal/ISignal.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Threading;
+
+namespace Hangfire.Mongo.Signal
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public interface ISignal
+    {
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="name"></param>
+        void Set(string name);
+
+        /// <summary>
+        /// Wait for a signal with name.
+        /// </summary>
+        /// <param name="name">
+        /// Name of the signal to wait for.
+        /// </param>
+        /// <param name="timeout">
+        /// The timeout for the wait.
+        /// </param>
+        void Wait(string name, TimeSpan timeout);
+
+        /// <summary>
+        /// Wait for a signal with name.
+        /// </summary>
+        /// <param name="name">
+        /// Name of the signal to wait for.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// The cancelation token for canceling the blocking wait.
+        /// </param>
+        /// <exception cref="System.OperationCanceledException">
+        /// Thrown if wait is cancelled
+        /// </exception>
+        void Wait(string name, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Wait for a signal with one of the names.
+        /// </summary>
+        /// <param name="names">
+        /// Names of the signal to wait for.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// The cancelation token for canceling the blocking wait.
+        /// </param>
+        /// <exception cref="System.OperationCanceledException">
+        /// Thrown if wait is cancelled
+        /// </exception>
+        void Wait(string[] names, CancellationToken cancellationToken);
+
+    }
+}

--- a/src/Hangfire.Mongo/Signal/Mongo/MongoSignal.cs
+++ b/src/Hangfire.Mongo/Signal/Mongo/MongoSignal.cs
@@ -19,12 +19,6 @@ namespace Hangfire.Mongo.Signal.Mongo
 
         private IMongoCollection<SignalDto> _signal;
 
-        /// <summary>
-        /// ctor
-        /// </summary>
-        /// <param name="signal">
-        /// The signal collection
-        /// </param>
         internal MongoSignal(IMongoCollection<SignalDto> signal)
         {
             _signal = signal ?? throw new ArgumentNullException(nameof(signal));
@@ -65,11 +59,6 @@ namespace Hangfire.Mongo.Signal.Mongo
                     EventWaitHandles
                         .GetOrAdd(document.Name, n => new EventWaitHandle(false, EventResetMode.AutoReset))
                         .Set();
-                    //    if (signalDto != null)
-                    //    {
-                    //        System.Diagnostics.Debug.WriteLine($@"*** FOUND: {signalDto.Name} ({Thread.CurrentThread.ManagedThreadId})");
-                    //    }
-                    //}
                 }, cancellationToken).ContinueWith(t =>
                 {
                     // TODO: Log if canceled?
@@ -82,12 +71,6 @@ namespace Hangfire.Mongo.Signal.Mongo
             }
         }
 
-        /// <summary>
-        /// Send signal identified by name
-        /// </summary>
-        /// <param name="name">
-        /// The name of the signal to set
-        /// </param>
         public void Set(string name)
         {
             if (name == null)
@@ -108,9 +91,11 @@ namespace Hangfire.Mongo.Signal.Mongo
             System.Diagnostics.Debug.WriteLine($@"*** SET: {name} ({Thread.CurrentThread.ManagedThreadId})");
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
+        public void Wait(string name)
+        {
+            Wait(name, TimeSpan.MaxValue);
+        }
+
         public void Wait(string name, TimeSpan timeout)
         {
             if (name == null)
@@ -135,18 +120,6 @@ namespace Hangfire.Mongo.Signal.Mongo
             System.Diagnostics.Debug.WriteLine($@"<<< WAIT: {name} ({Thread.CurrentThread.ManagedThreadId})");
         }
 
-        /// <summary>
-        /// Wait for a signal with name.
-        /// </summary>
-        /// <param name="name">
-        /// Name of the signal to wait for.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// The cancelation token for canceling the blocking wait.
-        /// </param>
-        /// <exception cref="System.OperationCanceledException">
-        /// Thrown if wait is cancelled
-        /// </exception>
         public void Wait(string name, CancellationToken cancellationToken)
         {
             if (name == null)
@@ -163,25 +136,13 @@ namespace Hangfire.Mongo.Signal.Mongo
             System.Diagnostics.Debug.WriteLine($@"<<< WAIT: {name} ({Thread.CurrentThread.ManagedThreadId})");
         }
 
-        /// <summary>
-        /// Wait for a signal with one of the names.
-        /// </summary>
-        /// <param name="names">
-        /// Names of the signal to wait for.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// The cancelation token for canceling the blocking wait.
-        /// </param>
-        /// <exception cref="System.OperationCanceledException">
-        /// Thrown if wait is cancelled
-        /// </exception>
         public void Wait(string[] names, CancellationToken cancellationToken)
         {
             if (names == null)
             {
                 throw new ArgumentNullException(nameof(names));
             }
-            if (names.Any(string.IsNullOrEmpty))
+            if (names.Length == 0 || names.Any(string.IsNullOrEmpty))
             {
                 throw new ArgumentException("Name should not be empty", nameof(names));
             }

--- a/src/Hangfire.Mongo/Signal/Mongo/MongoSignal.cs
+++ b/src/Hangfire.Mongo/Signal/Mongo/MongoSignal.cs
@@ -1,0 +1,195 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Hangfire.Mongo.Dto;
+using MongoDB.Driver;
+
+namespace Hangfire.Mongo.Signal.Mongo
+{
+
+    /// <summary>
+    /// Provide interprocess/server signalling
+    /// </summary>
+    internal class MongoSignal : ISignal
+    {
+
+        private static readonly ConcurrentDictionary<string, EventWaitHandle> EventWaitHandles = new ConcurrentDictionary<string, EventWaitHandle>();
+
+        private IMongoCollection<SignalDto> _signal;
+
+        /// <summary>
+        /// ctor
+        /// </summary>
+        /// <param name="signal">
+        /// The signal collection
+        /// </param>
+        internal MongoSignal(IMongoCollection<SignalDto> signal)
+        {
+            _signal = signal ?? throw new ArgumentNullException(nameof(signal));
+        }
+
+        public void Listen(CancellationToken cancellationToken)
+        {
+            var options = new FindOptions<SignalDto>
+            {
+                // Our cursor is a tailable cursor and informs the server to await
+                CursorType = CursorType.TailableAwait,
+                // Make sure to time out once in a while to avoid complete blocking operation
+                MaxAwaitTime = TimeSpan.FromMinutes(1),
+            };
+
+            var filterBuilder = Builders<SignalDto>.Filter;
+            var filter = filterBuilder.Eq(s => s.Signaled, true);
+
+            using (var cursor = _signal.FindSync(filter, options, cancellationToken))
+            {
+                System.Diagnostics.Debug.WriteLine($@"*** LISTEN ({Thread.CurrentThread.ManagedThreadId})");
+                cancellationToken.ThrowIfCancellationRequested();
+                cursor.ForEachAsync(document =>
+                {
+                    var signalDto = _signal.FindOneAndUpdate(
+                        s => s.Id == document.Id,
+                        Builders<SignalDto>.Update.Set(s => s.Signaled, false),
+                        null,
+                        cancellationToken);
+                    if (signalDto == null)
+                    {
+                        System.Diagnostics.Debug.WriteLine($@"*** TRIGGERED ({Thread.CurrentThread.ManagedThreadId})");
+                    }
+                    else
+                    {
+                        System.Diagnostics.Debug.WriteLine($@"*** OWNED: {signalDto.Name} ({Thread.CurrentThread.ManagedThreadId})");
+                    }
+                    EventWaitHandles
+                        .GetOrAdd(document.Name, n => new EventWaitHandle(false, EventResetMode.AutoReset))
+                        .Set();
+                    //    if (signalDto != null)
+                    //    {
+                    //        System.Diagnostics.Debug.WriteLine($@"*** FOUND: {signalDto.Name} ({Thread.CurrentThread.ManagedThreadId})");
+                    //    }
+                    //}
+                }, cancellationToken).ContinueWith(t =>
+                {
+                    // TODO: Log if canceled?
+                    if (t.IsFaulted)
+                    {
+                        var messages = string.Join(Environment.NewLine, t.Exception.InnerExceptions.Select(e => e.Message));
+                        System.Diagnostics.Debug.WriteLine($@"*** FAULT: {messages} ({Thread.CurrentThread.ManagedThreadId})");
+                    }
+                }).Wait();
+            }
+        }
+
+        /// <summary>
+        /// Send signal identified by name
+        /// </summary>
+        /// <param name="name">
+        /// The name of the signal to set
+        /// </param>
+        public void Set(string name)
+        {
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentException("Name should not be empty", nameof(name));
+            }
+
+            var update = Builders<SignalDto>.Update
+                .Set(s => s.Signaled, true)
+                .Set(s => s.Name, name)
+                .CurrentDate(s => s.TimeStamp);
+            _signal.UpdateOne(_ => false, update, new UpdateOptions { IsUpsert = true });
+
+            System.Diagnostics.Debug.WriteLine($@"*** SET: {name} ({Thread.CurrentThread.ManagedThreadId})");
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public void Wait(string name, TimeSpan timeout)
+        {
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentException("Name should not be empty", nameof(name));
+            }
+
+            var e = EventWaitHandles.GetOrAdd(name, n => new EventWaitHandle(false, EventResetMode.AutoReset));
+            System.Diagnostics.Debug.WriteLine($@">>> WAIT: {name} ({Thread.CurrentThread.ManagedThreadId})");
+            if (timeout == TimeSpan.MaxValue)
+            {
+                e.WaitOne();
+            }
+            else
+            {
+                e.WaitOne(timeout);
+            }
+            System.Diagnostics.Debug.WriteLine($@"<<< WAIT: {name} ({Thread.CurrentThread.ManagedThreadId})");
+        }
+
+        /// <summary>
+        /// Wait for a signal with name.
+        /// </summary>
+        /// <param name="name">
+        /// Name of the signal to wait for.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// The cancelation token for canceling the blocking wait.
+        /// </param>
+        /// <exception cref="System.OperationCanceledException">
+        /// Thrown if wait is cancelled
+        /// </exception>
+        public void Wait(string name, CancellationToken cancellationToken)
+        {
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentException("Name should not be empty", nameof(name));
+            }
+
+            System.Diagnostics.Debug.WriteLine($@">>> WAIT: {name} ({Thread.CurrentThread.ManagedThreadId})");
+            Task.Run(() => Wait(name, TimeSpan.MaxValue)).Wait(cancellationToken);
+            System.Diagnostics.Debug.WriteLine($@"<<< WAIT: {name} ({Thread.CurrentThread.ManagedThreadId})");
+        }
+
+        /// <summary>
+        /// Wait for a signal with one of the names.
+        /// </summary>
+        /// <param name="names">
+        /// Names of the signal to wait for.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// The cancelation token for canceling the blocking wait.
+        /// </param>
+        /// <exception cref="System.OperationCanceledException">
+        /// Thrown if wait is cancelled
+        /// </exception>
+        public void Wait(string[] names, CancellationToken cancellationToken)
+        {
+            if (names == null)
+            {
+                throw new ArgumentNullException(nameof(names));
+            }
+            if (names.Any(string.IsNullOrEmpty))
+            {
+                throw new ArgumentException("Name should not be empty", nameof(names));
+            }
+
+            System.Diagnostics.Debug.WriteLine($@">>> WAIT: {string.Join(",", names)} ({Thread.CurrentThread.ManagedThreadId})");
+            Task.WaitAny(names.Select(n => Task.Run(() => Wait(n, TimeSpan.MaxValue))).ToArray(), cancellationToken);
+            System.Diagnostics.Debug.WriteLine($@"<<< WAIT: {string.Join(",", names)} ({Thread.CurrentThread.ManagedThreadId})");
+        }
+
+    }
+}

--- a/src/Hangfire.Mongo/Signal/Mongo/MongoSignal.cs
+++ b/src/Hangfire.Mongo/Signal/Mongo/MongoSignal.cs
@@ -12,7 +12,7 @@ namespace Hangfire.Mongo.Signal.Mongo
     /// <summary>
     /// Provide interprocess/server signalling
     /// </summary>
-    internal class MongoSignal : ISignal
+    internal class MongoSignal : IPersistentSignal
     {
 
         private static readonly ConcurrentDictionary<string, EventWaitHandle> EventWaitHandles = new ConcurrentDictionary<string, EventWaitHandle>();

--- a/src/Hangfire.Mongo/Signal/Mongo/MongoSignalBackgroundProcess.cs
+++ b/src/Hangfire.Mongo/Signal/Mongo/MongoSignalBackgroundProcess.cs
@@ -1,28 +1,28 @@
 ﻿using System;
 using System.Threading;
 using Hangfire.Logging;
+using Hangfire.Mongo.Dto;
 using Hangfire.Server;
+using MongoDB.Driver;
 
 namespace Hangfire.Mongo.Signal.Mongo
 {
     /// <summary>
     /// 
     /// </summary>
-    public class MongoSignalManager : IBackgroundProcess, IServerComponent
+    public class MongoSignalBackgroundProcess : IBackgroundProcess, IServerComponent
     {
         private static readonly ILog Logger = LogProvider.For<ExpirationManager>();
 
-        private readonly MongoStorage _storage;
-        private readonly IPersistentSignal _signal;
+        private readonly MongoSignal _signal;
 
         /// <summary>
         /// Constructs expiration manager with one hour checking interval
         /// </summary>
-        /// <param name="storage">MongoDB storage</param>
-        public MongoSignalManager(MongoStorage storage)
+        /// <param name="signalCollection">MongoDB storage</param>
+        public MongoSignalBackgroundProcess(IMongoCollection<SignalDto> signalCollection)
         {
-            _storage = storage ?? throw new ArgumentNullException(nameof(storage));
-            _signal = new MongoSignal(_storage.Connection.Signal);
+            _signal = new MongoSignal(signalCollection);
         }
 
         /// <summary>
@@ -40,11 +40,7 @@ namespace Hangfire.Mongo.Signal.Mongo
         /// <param name="cancellationToken">Cancellation token</param>
         public void Execute(CancellationToken cancellationToken)
         {
-            using (var connection = _storage.CreateAndOpenConnection())
-            {
-                var mongoSignal = _signal as MongoSignal;
-                mongoSignal.Listen(cancellationToken);
-            }
+            _signal.Listen(cancellationToken);
         }
 
         /// <summary>
@@ -52,7 +48,7 @@ namespace Hangfire.Mongo.Signal.Mongo
         /// </summary>
         public override string ToString()
         {
-            return "Mongo Signal Manager";
+            return "Mongo Signal Background Process";
         }
 
     }

--- a/src/Hangfire.Mongo/Signal/Mongo/MongoSignalManager.cs
+++ b/src/Hangfire.Mongo/Signal/Mongo/MongoSignalManager.cs
@@ -40,15 +40,11 @@ namespace Hangfire.Mongo.Signal.Mongo
         /// <param name="cancellationToken">Cancellation token</param>
         public void Execute(CancellationToken cancellationToken)
         {
-            System.Diagnostics.Debug.WriteLine($@">>> Execute ({Thread.CurrentThread.ManagedThreadId})");
-
             using (var connection = _storage.CreateAndOpenConnection())
             {
                 var mongoSignal = _signal as MongoSignal;
                 mongoSignal.Listen(cancellationToken);
             }
-
-            System.Diagnostics.Debug.WriteLine($@"<<< Execute ({Thread.CurrentThread.ManagedThreadId})");
         }
 
         /// <summary>

--- a/src/Hangfire.Mongo/Signal/Mongo/MongoSignalManager.cs
+++ b/src/Hangfire.Mongo/Signal/Mongo/MongoSignalManager.cs
@@ -13,7 +13,7 @@ namespace Hangfire.Mongo.Signal.Mongo
         private static readonly ILog Logger = LogProvider.For<ExpirationManager>();
 
         private readonly MongoStorage _storage;
-        private readonly ISignal _signal;
+        private readonly IPersistentSignal _signal;
 
         /// <summary>
         /// Constructs expiration manager with one hour checking interval

--- a/src/Hangfire.Mongo/Signal/Mongo/MongoSignalManager.cs
+++ b/src/Hangfire.Mongo/Signal/Mongo/MongoSignalManager.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Threading;
 using Hangfire.Logging;
-using Hangfire.Mongo.Signal;
-using Hangfire.Mongo.Signal.Mongo;
 using Hangfire.Server;
 
-namespace Hangfire.Mongo
+namespace Hangfire.Mongo.Signal.Mongo
 {
     /// <summary>
     /// 

--- a/src/Hangfire.Mongo/Signal/MongoSignalManager.cs
+++ b/src/Hangfire.Mongo/Signal/MongoSignalManager.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Threading;
+using Hangfire.Logging;
+using Hangfire.Mongo.Signal;
+using Hangfire.Mongo.Signal.Mongo;
+using Hangfire.Server;
+
+namespace Hangfire.Mongo
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class MongoSignalManager : IBackgroundProcess, IServerComponent
+    {
+        private static readonly ILog Logger = LogProvider.For<ExpirationManager>();
+
+        private readonly MongoStorage _storage;
+        private readonly ISignal _signal;
+
+        /// <summary>
+        /// Constructs expiration manager with one hour checking interval
+        /// </summary>
+        /// <param name="storage">MongoDB storage</param>
+        /// <param name="signal"></param>
+        public MongoSignalManager(MongoStorage storage, ISignal signal)
+        {
+            _storage = storage ?? throw new ArgumentNullException(nameof(storage));
+            _signal = signal ?? throw new ArgumentNullException(nameof(signal));
+        }
+
+        /// <summary>
+        /// Run expiration manager to remove outdated records
+        /// </summary>
+        /// <param name="context">Background processing context</param>
+        public void Execute(BackgroundProcessContext context)
+        {
+            Execute(context.CancellationToken);
+        }
+
+        /// <summary>
+        /// Run expiration manager to remove outdated records
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token</param>
+        public void Execute(CancellationToken cancellationToken)
+        {
+            System.Diagnostics.Debug.WriteLine($@">>> Execute ({Thread.CurrentThread.ManagedThreadId})");
+
+            using (var connection = _storage.CreateAndOpenConnection())
+            {
+                var mongoSignal = _signal as MongoSignal;
+                mongoSignal.Listen(cancellationToken);
+            }
+
+            System.Diagnostics.Debug.WriteLine($@"<<< Execute ({Thread.CurrentThread.ManagedThreadId})");
+        }
+
+        /// <summary>
+        /// Returns text representation of the object
+        /// </summary>
+        public override string ToString()
+        {
+            return "Mongo Signal Manager";
+        }
+
+    }
+}

--- a/src/Hangfire.Mongo/Signal/MongoSignalManager.cs
+++ b/src/Hangfire.Mongo/Signal/MongoSignalManager.cs
@@ -21,11 +21,10 @@ namespace Hangfire.Mongo
         /// Constructs expiration manager with one hour checking interval
         /// </summary>
         /// <param name="storage">MongoDB storage</param>
-        /// <param name="signal"></param>
-        public MongoSignalManager(MongoStorage storage, ISignal signal)
+        public MongoSignalManager(MongoStorage storage)
         {
             _storage = storage ?? throw new ArgumentNullException(nameof(storage));
-            _signal = signal ?? throw new ArgumentNullException(nameof(signal));
+            _signal = new MongoSignal(_storage.Connection.Signal);
         }
 
         /// <summary>


### PR DESCRIPTION
Moving away from polling the MongoDB every 15 sec (by default) to listening on a [tailable cursor](https://docs.mongodb.com/manual/core/tailable-cursors) in a capped collection.

This way Hangfire.Mongo will be much more reactive and provide jobs when Hangfire enqueues them.