### PR TITLE
Changed job stats aggregation filter

### DIFF
--- a/src/Hangfire.Mongo/MongoMonitoringApi.cs
+++ b/src/Hangfire.Mongo/MongoMonitoringApi.cs
@@ -117,7 +117,7 @@ namespace Hangfire.Mongo
                 var stats = new StatisticsDto();
 
                 var countByStates = database.Job.Aggregate()
-                    .Match(Builders<JobDto>.Filter.Ne(_ => _.StateName, null))
+                    .Match(Builders<JobDto>.Filter.In(_ => _.StateName, new [] { EnqueuedState.StateName, FailedState.StateName, ProcessingState.StateName, ScheduledState.StateName }))
                     .Group(dto => new { dto.StateName }, dtos => new { StateName = dtos.First().StateName, Count = dtos.Count() })
                     .ToList().ToDictionary(kv => kv.StateName, kv => kv.Count);
 


### PR DESCRIPTION
Hi @MarLoe,

This PR should fix issue #104 

The aggregation using `{"StateName":{"$ne": null}}` was actually scanning the whole job collection but I've noticed that the function `getCountIfExists` which is the place where we use the dictionary returned from the aggregation was only being used by these statuses: 

```
stats.Enqueued = getCountIfExists(EnqueuedState.StateName);
stats.Failed = getCountIfExists(FailedState.StateName);
stats.Processing = getCountIfExists(ProcessingState.StateName);
stats.Scheduled = getCountIfExists(ScheduledState.StateName);
```

So, to optimize the aggregation, I've added these statuses in the match filter as suggested by @mathieukempe 

Cheers,
Carlos

