### PR TITLE
Only apply default MongoDB conventions to DTOs

### DIFF
--- a/src/Hangfire.Mongo/Database/HangfireDbContext.cs
+++ b/src/Hangfire.Mongo/Database/HangfireDbContext.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using Hangfire.Mongo.Dto;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Conventions;
 using MongoDB.Driver;
 
 namespace Hangfire.Mongo.Database
@@ -19,6 +21,28 @@ namespace Hangfire.Mongo.Database
         {
             _prefix = prefix;
             ConnectionId = Guid.NewGuid().ToString();
+
+            var conventionPack = new ConventionPack();
+            conventionPack.Append(DefaultConventionPack.Instance);
+            conventionPack.Append(AttributeConventionPack.Instance);
+            var conventionRunner = new ConventionRunner(conventionPack);
+
+            BsonClassMap.RegisterClassMap<AggregatedCounterDto>(cm => conventionRunner.Apply(cm));
+            BsonClassMap.RegisterClassMap<CounterDto>(cm => conventionRunner.Apply(cm));
+            BsonClassMap.RegisterClassMap<DistributedLockDto>(cm => conventionRunner.Apply(cm));
+            BsonClassMap.RegisterClassMap<HashDto>(cm => conventionRunner.Apply(cm));
+            BsonClassMap.RegisterClassMap<JobDetailedDto>(cm => conventionRunner.Apply(cm));
+            BsonClassMap.RegisterClassMap<JobDto>(cm => conventionRunner.Apply(cm));
+            BsonClassMap.RegisterClassMap<JobQueueDto>(cm => conventionRunner.Apply(cm));
+            BsonClassMap.RegisterClassMap<KeyValueDto>(cm => conventionRunner.Apply(cm));
+            BsonClassMap.RegisterClassMap<ExpiringKeyValueDto>(cm => conventionRunner.Apply(cm));
+            BsonClassMap.RegisterClassMap<ListDto>(cm => conventionRunner.Apply(cm));
+            BsonClassMap.RegisterClassMap<SchemaDto>(cm => conventionRunner.Apply(cm));
+            BsonClassMap.RegisterClassMap<ServerDataDto>(cm => conventionRunner.Apply(cm));
+            BsonClassMap.RegisterClassMap<ServerDto>(cm => conventionRunner.Apply(cm));
+            BsonClassMap.RegisterClassMap<SetDto>(cm => conventionRunner.Apply(cm));
+            BsonClassMap.RegisterClassMap<SignalDto>(cm => conventionRunner.Apply(cm));
+            BsonClassMap.RegisterClassMap<StateDto>(cm => conventionRunner.Apply(cm));
         }
 
         /// <summary>

--- a/src/Hangfire.Mongo/Database/HangfireDbContext.cs
+++ b/src/Hangfire.Mongo/Database/HangfireDbContext.cs
@@ -17,11 +17,8 @@ namespace Hangfire.Mongo.Database
 
         internal IMongoDatabase Database { get; }
 
-        private HangfireDbContext(string prefix)
+        static HangfireDbContext()
         {
-            _prefix = prefix;
-            ConnectionId = Guid.NewGuid().ToString();
-
             var conventionPack = new ConventionPack();
             conventionPack.Append(DefaultConventionPack.Instance);
             conventionPack.Append(AttributeConventionPack.Instance);
@@ -43,6 +40,12 @@ namespace Hangfire.Mongo.Database
             BsonClassMap.RegisterClassMap<SetDto>(cm => conventionRunner.Apply(cm));
             BsonClassMap.RegisterClassMap<SignalDto>(cm => conventionRunner.Apply(cm));
             BsonClassMap.RegisterClassMap<StateDto>(cm => conventionRunner.Apply(cm));
+        }
+
+        private HangfireDbContext(string prefix)
+        {
+            _prefix = prefix;
+            ConnectionId = Guid.NewGuid().ToString();
         }
 
         /// <summary>


### PR DESCRIPTION
Avoid any globally registered conventions from `ConventionRegistry` by explicitly registering class maps for all DTO types and avoiding the use of `AutoMap()`. This change applies only the default conventions by explicitly running these convention packs on the class maps.

This is the most all encompassing fix for convention related problems I could come up with. Not sure if this is preferred over handling each problematic convention individually. It's going to need some testing to make sure it doesn't break existing behaviour.

Manually having to register each DTO class map is not the most maintainable solution. I initially tried another approach by looping over all types in the Hangfire.Mongo.Dto namespace using `Assembly.GetExecutingAssembly().GetTypes().Where(...)` and `typeof(HangfireDbContext).Assembly.GetTypes().Where(...)`. However this does not work in .NET Standard 1.5. Maybe there is a way around this that I'm not aware of.

These registrations do not have to happen in this exact location, so there is possibly a more suitable place to put them. As long as they happen before the first time a DTO is serialized or deserialized it should be fine.

This should fix the issue in #110. The `Bson*` attributes previously used as workarounds for convention troubles may no longer be needed. See #85 for example.