### PR TITLE
Apply default MongoDB conventions to DTOs

### DIFF
--- a/src/Hangfire.Mongo.Tests/MongoConventionsFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoConventionsFacts.cs
@@ -1,0 +1,29 @@
+﻿using Hangfire.Mongo.Tests.Utils;
+using MongoDB.Bson.Serialization.Conventions;
+using Xunit;
+
+namespace Hangfire.Mongo.Tests
+{
+
+    [Collection("Database")]
+    public class MongoConventionsFacts
+    {
+
+        [Fact, CleanDatabase(false)]
+        public void Conventions_UsesOwnConventionsForDtoNameSpace_WhenCamelCaseIsRegistered()
+        {
+            // ARRANGE
+            var conventionPack = new ConventionPack { new CamelCaseElementNameConvention() };
+            ConventionRegistry.Register("camelCase", conventionPack, t => true);
+
+            // ACT
+            // This line will throw during migration if camelCase is active for the Dto namespace.
+            var connection = ConnectionUtils.CreateConnection();
+
+            // ASSERT
+            Assert.NotNull(connection);
+        }
+
+    }
+
+}

--- a/src/Hangfire.Mongo.Tests/Utils/ConnectionUtils.cs
+++ b/src/Hangfire.Mongo.Tests/Utils/ConnectionUtils.cs
@@ -12,12 +12,12 @@ namespace Hangfire.Mongo.Tests.Utils
         private const string DefaultDatabaseName = @"Hangfire-Mongo-Tests";
         private const string DefaultConnectionStringTemplate = @"mongodb://localhost";
 
-        private static string GetDatabaseName()
+        public static string GetDatabaseName()
         {
             return Environment.GetEnvironmentVariable(DatabaseVariable) ?? DefaultDatabaseName;
         }
 
-        private static string GetConnectionString()
+        public static string GetConnectionString()
         {
             return string.Format(GetConnectionStringTemplate(), GetDatabaseName());
         }

--- a/src/Hangfire.Mongo/Dto/DistributedLockDto.cs
+++ b/src/Hangfire.Mongo/Dto/DistributedLockDto.cs
@@ -18,7 +18,6 @@ namespace Hangfire.Mongo.Dto
         /// <summary>
         /// The name of the resource being held.
         /// </summary>
-        [BsonElement(nameof(Resource))]
         public string Resource { get; set; }
 
         /// <summary>
@@ -26,7 +25,6 @@ namespace Hangfire.Mongo.Dto
         /// This is used if the lock is not maintained or 
         /// cleaned up by the owner (e.g. process was shut down).
         /// </summary>
-        [BsonElement(nameof(ExpireAt))]
         public DateTime ExpireAt { get; set; }
     }
 }

--- a/src/Hangfire.Mongo/Dto/HashDto.cs
+++ b/src/Hangfire.Mongo/Dto/HashDto.cs
@@ -1,11 +1,8 @@
-﻿using MongoDB.Bson.Serialization.Attributes;
-
-namespace Hangfire.Mongo.Dto
+﻿namespace Hangfire.Mongo.Dto
 {
 #pragma warning disable 1591
     public class HashDto : ExpiringKeyValueDto
     {
-        [BsonElement(nameof(Field))]
         public string Field { get; set; }
     }
 #pragma warning restore 1591

--- a/src/Hangfire.Mongo/Dto/JobDetailedDto.cs
+++ b/src/Hangfire.Mongo/Dto/JobDetailedDto.cs
@@ -11,31 +11,22 @@ namespace Hangfire.Mongo.Dto
         [BsonId]
         public string Id { get; set; }
 
-        [BsonElement(nameof(InvocationData))]
         public string InvocationData { get; set; }
 
-        [BsonElement(nameof(Arguments))]
         public string Arguments { get; set; }
 
-        [BsonElement(nameof(CreatedAt))]
         public DateTime CreatedAt { get; set; }
 
-        [BsonElement(nameof(ExpireAt))]
         public DateTime? ExpireAt { get; set; }
 
-        [BsonElement(nameof(FetchedAt))]
         public DateTime? FetchedAt { get; set; }
 
-        [BsonElement(nameof(StateId))]
         public ObjectId StateId { get; set; }
 
-        [BsonElement(nameof(StateName))]
         public string StateName { get; set; }
 
-        [BsonElement(nameof(StateReason))]
         public string StateReason { get; set; }
 
-        [BsonElement(nameof(StateData))]
         public Dictionary<string, string> StateData { get; set; }
     }
 #pragma warning restore 1591

--- a/src/Hangfire.Mongo/Dto/JobDto.cs
+++ b/src/Hangfire.Mongo/Dto/JobDto.cs
@@ -11,26 +11,19 @@ namespace Hangfire.Mongo.Dto
         [BsonId(IdGenerator = typeof(StringObjectIdGenerator))]
         public string Id { get; set; }
 
-        [BsonElement(nameof(StateName))]
         public string StateName { get; set; }
 
-        [BsonElement(nameof(InvocationData))]
         public string InvocationData { get; set; }
 
-        [BsonElement(nameof(Arguments))]
         public string Arguments { get; set; }
 
-        [BsonElement(nameof(Parameters))]
         public Dictionary<string, string> Parameters { get; set; } = new Dictionary<string, string>();
 
-        [BsonElement(nameof(StateHistory))]
         public StateDto[] StateHistory { get; set; } = new StateDto[0];
 
-        [BsonElement(nameof(CreatedAt))]
         public DateTime CreatedAt { get; set; }
 
-        [BsonElement(nameof(ExpireAt))]
         public DateTime? ExpireAt { get; set; }
-    } 
+    }
 #pragma warning restore 1591
 }

--- a/src/Hangfire.Mongo/Dto/JobQueueDto.cs
+++ b/src/Hangfire.Mongo/Dto/JobQueueDto.cs
@@ -11,13 +11,10 @@ namespace Hangfire.Mongo.Dto
         [BsonId]
         public ObjectId Id { get; set; }
 
-        [BsonElement(nameof(JobId))]
         public string JobId { get; set; }
 
-        [BsonElement(nameof(Queue))]
         public string Queue { get; set; }
 
-        [BsonElement(nameof(FetchedAt))]
         public DateTime? FetchedAt { get; set; }
 
     }

--- a/src/Hangfire.Mongo/Dto/KeyValueDto.cs
+++ b/src/Hangfire.Mongo/Dto/KeyValueDto.cs
@@ -18,16 +18,13 @@ namespace Hangfire.Mongo.Dto
         [BsonId]
         public ObjectId Id { get; set; }
 
-        [BsonElement(nameof(Key))]
         public string Key { get; set; }
 
-        [BsonElement(nameof(Value))]
         public object Value { get; set; }
     }
 
     public class ExpiringKeyValueDto : KeyValueDto
     {
-        [BsonElement(nameof(ExpireAt))]
         public DateTime? ExpireAt { get; set; }
     }
 #pragma warning restore 1591

--- a/src/Hangfire.Mongo/Dto/ListDto.cs
+++ b/src/Hangfire.Mongo/Dto/ListDto.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using MongoDB.Bson;
-using MongoDB.Bson.Serialization.Attributes;
-
-namespace Hangfire.Mongo.Dto
+﻿namespace Hangfire.Mongo.Dto
 {
 #pragma warning disable 1591
     public class ListDto : ExpiringKeyValueDto

--- a/src/Hangfire.Mongo/Dto/SchemaDto.cs
+++ b/src/Hangfire.Mongo/Dto/SchemaDto.cs
@@ -1,6 +1,4 @@
-﻿using Hangfire.Mongo.Migration;
-using MongoDB.Bson;
-using MongoDB.Bson.Serialization.Attributes;
+﻿using MongoDB.Bson.Serialization.Attributes;
 
 namespace Hangfire.Mongo.Dto
 {

--- a/src/Hangfire.Mongo/Dto/ServerDataDto.cs
+++ b/src/Hangfire.Mongo/Dto/ServerDataDto.cs
@@ -1,18 +1,14 @@
 ﻿using System;
-using MongoDB.Bson.Serialization.Attributes;
 
 namespace Hangfire.Mongo.Dto
 {
 #pragma warning disable 1591
     internal class ServerDataDto
     {
-        [BsonElement(nameof(WorkerCount))]
         public int WorkerCount { get; set; }
 
-        [BsonElement(nameof(Queues))]
         public string[] Queues { get; set; }
 
-        [BsonElement(nameof(StartedAt))]
         public DateTime? StartedAt { get; set; }
     }
 #pragma warning restore 1591

--- a/src/Hangfire.Mongo/Dto/ServerDto.cs
+++ b/src/Hangfire.Mongo/Dto/ServerDto.cs
@@ -9,10 +9,8 @@ namespace Hangfire.Mongo.Dto
         [BsonId]
         public string Id { get; set; }
 
-        [BsonElement(nameof(Data))]
         public string Data { get; set; }
 
-        [BsonElement(nameof(LastHeartbeat))]
         public DateTime? LastHeartbeat { get; set; }
     }
 #pragma warning restore 1591

--- a/src/Hangfire.Mongo/Dto/SetDto.cs
+++ b/src/Hangfire.Mongo/Dto/SetDto.cs
@@ -1,11 +1,8 @@
-﻿using MongoDB.Bson.Serialization.Attributes;
-
-namespace Hangfire.Mongo.Dto
+﻿namespace Hangfire.Mongo.Dto
 {
 #pragma warning disable 1591
     public class SetDto : ExpiringKeyValueDto
     {
-        [BsonElement(nameof(Score))]
         public double Score { get; set; }
     }
 #pragma warning restore 1591

--- a/src/Hangfire.Mongo/Dto/StateDto.cs
+++ b/src/Hangfire.Mongo/Dto/StateDto.cs
@@ -1,22 +1,17 @@
 using System;
 using System.Collections.Generic;
-using MongoDB.Bson.Serialization.Attributes;
 
 namespace Hangfire.Mongo.Dto
 {
 #pragma warning disable 1591
     public class StateDto
     {
-        [BsonElement(nameof(Name))]
         public string Name { get; set; }
 
-        [BsonElement(nameof(Reason))]
         public string Reason { get; set; }
 
-        [BsonElement(nameof(CreatedAt))]
         public DateTime CreatedAt { get; set; }
 
-        [BsonElement(nameof(Data))]
         public Dictionary<string, string> Data { get; set; }
     }
 #pragma warning restore 1591

--- a/src/Hangfire.Mongo/MongoStorage.cs
+++ b/src/Hangfire.Mongo/MongoStorage.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text.RegularExpressions;
 using Hangfire.Logging;
 using Hangfire.Mongo.Database;
@@ -10,6 +11,8 @@ using Hangfire.Mongo.StateHandlers;
 using Hangfire.Server;
 using Hangfire.States;
 using Hangfire.Storage;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Conventions;
 using MongoDB.Driver;
 
 namespace Hangfire.Mongo
@@ -28,6 +31,31 @@ namespace Hangfire.Mongo
         private readonly MongoClientSettings _mongoClientSettings;
 
         private readonly MongoStorageOptions _storageOptions;
+
+
+        static MongoStorage()
+        {
+            // We will register all our Dto classes with the default conventions.
+            // By doing this, we can safely use strings for referencing class
+            // property names with risking to have a mismatch with any convention
+            // used by bson serializer.
+            var conventionPack = new ConventionPack();
+            conventionPack.Append(DefaultConventionPack.Instance);
+            conventionPack.Append(AttributeConventionPack.Instance);
+            var conventionRunner = new ConventionRunner(conventionPack);
+
+            var assembly = typeof(MongoStorage).GetTypeInfo().Assembly;
+            var classMaps = assembly.DefinedTypes
+                .Where(t => t.IsClass && !t.IsAbstract && !t.IsGenericType && t.Namespace == "Hangfire.Mongo.Dto")
+                .Select(t => new BsonClassMap(t.AsType()));
+
+            foreach (var classMap in classMaps)
+            {
+                conventionRunner.Apply(classMap);
+                BsonClassMap.RegisterClassMap(classMap);
+            }
+        }
+
 
         /// <summary>
         /// Constructs Job Storage by database connection string and name
@@ -66,6 +94,7 @@ namespace Hangfire.Mongo
 
             Connection = new HangfireDbContext(connectionString, databaseName, storageOptions.Prefix);
             Connection.Init(_storageOptions);
+
             var defaultQueueProvider = new MongoJobQueueProvider(_storageOptions);
             QueueProviders = new PersistentJobQueueProviderCollection(defaultQueueProvider);
         }
@@ -106,6 +135,7 @@ namespace Hangfire.Mongo
             _storageOptions = storageOptions;
 
             Connection = new HangfireDbContext(mongoClientSettings, databaseName, _storageOptions.Prefix);
+
             var defaultQueueProvider = new MongoJobQueueProvider(_storageOptions);
             QueueProviders = new PersistentJobQueueProviderCollection(defaultQueueProvider);
         }


### PR DESCRIPTION
Avoid any globally registered conventions from ConventionRegistry by
explicitly registering class maps for all DTO types and avoiding the
use of AutoMap().
Apply only the standard conventions by running the default convention
packs on the class maps.

Inspiration and hard work comes from PR #111. Thanks to @janmagnet