### PR TITLE
Change state names to use those from Hangfire

### DIFF
--- a/src/Hangfire.Mongo.Tests/MongoConnectionFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoConnectionFacts.cs
@@ -9,6 +9,7 @@ using Hangfire.Mongo.Dto;
 using Hangfire.Mongo.PersistentJobQueue;
 using Hangfire.Mongo.Tests.Utils;
 using Hangfire.Server;
+using Hangfire.States;
 using Hangfire.Storage;
 using MongoDB.Bson;
 using MongoDB.Driver;
@@ -207,7 +208,7 @@ namespace Hangfire.Mongo.Tests
                     Id = ObjectId.GenerateNewId(),
                     InvocationData = JobHelper.ToJson(InvocationData.Serialize(job)),
                     Arguments = "[\"\\\"Arguments\\\"\"]",
-                    StateName = "Succeeded",
+                    StateName = SucceededState.StateName,
                     CreatedAt = DateTime.UtcNow
                 };
                 database.Job.InsertOne(jobDto);
@@ -216,7 +217,7 @@ namespace Hangfire.Mongo.Tests
 
                 Assert.NotNull(result);
                 Assert.NotNull(result.Job);
-                Assert.Equal("Succeeded", result.State);
+                Assert.Equal(SucceededState.StateName, result.State);
                 Assert.Equal("Arguments", result.Job.Args[0]);
                 Assert.Null(result.LoadException);
                 Assert.True(DateTime.UtcNow.AddMinutes(-1) < result.CreatedAt);
@@ -302,7 +303,7 @@ namespace Hangfire.Mongo.Tests
                     Id = ObjectId.GenerateNewId(),
                     InvocationData = JobHelper.ToJson(new InvocationData(null, null, null, null)),
                     Arguments = "[\"\\\"Arguments\\\"\"]",
-                    StateName = "Succeeded",
+                    StateName = SucceededState.StateName,
                     CreatedAt = DateTime.UtcNow
                 };
                 database.Job.InsertOne(jobDto);
@@ -470,7 +471,7 @@ namespace Hangfire.Mongo.Tests
                     CreatedAt = DateTime.UtcNow
                 };
                 database.Job.InsertOne(jobDto);
-                
+
 
                 connection.SetJobParameter(jobDto.Id.ToString(), "name", "value");
 

--- a/src/Hangfire.Mongo/MongoMonitoringApi.cs
+++ b/src/Hangfire.Mongo/MongoMonitoringApi.cs
@@ -141,14 +141,16 @@ namespace Hangfire.Mongo
 
                 stats.Servers = connection.Server.Count(new BsonDocument());
 
-                long[] succeededItems = connection.StateData.OfType<CounterDto>().Find(Builders<CounterDto>.Filter.Eq(_ => _.Key, "stats:succeeded")).ToList().Select(_ => (long)_.Value)
-                    .Concat(connection.StateData.OfType<AggregatedCounterDto>().Find(Builders<AggregatedCounterDto>.Filter.Eq(_ => _.Key, "stats:succeeded")).ToList().Select(_ => (long)_.Value))
+                var statsSucceeded = $@"stats:{State.Succeeded}";
+                var succeededItems = connection.StateData.OfType<CounterDto>().Find(Builders<CounterDto>.Filter.Eq(_ => _.Key, statsSucceeded)).ToList().Select(_ => (long)_.Value)
+                    .Concat(connection.StateData.OfType<AggregatedCounterDto>().Find(Builders<AggregatedCounterDto>.Filter.Eq(_ => _.Key, statsSucceeded)).ToList().Select(_ => (long)_.Value))
                     .ToArray();
 
                 stats.Succeeded = succeededItems.Any() ? succeededItems.Sum() : 0;
 
-                long[] deletedItems = connection.StateData.OfType<CounterDto>().Find(Builders<CounterDto>.Filter.Eq(_ => _.Key, "stats:deleted")).ToList().Select(_ => (long)_.Value)
-                    .Concat(connection.StateData.OfType<AggregatedCounterDto>().Find(Builders<AggregatedCounterDto>.Filter.Eq(_ => _.Key, "stats:deleted")).ToList().Select(_ => (long)_.Value))
+                var statsDeleted = $@"stats:{State.Deleted}";
+                var deletedItems = connection.StateData.OfType<CounterDto>().Find(Builders<CounterDto>.Filter.Eq(_ => _.Key, statsDeleted)).ToList().Select(_ => (long)_.Value)
+                    .Concat(connection.StateData.OfType<AggregatedCounterDto>().Find(Builders<AggregatedCounterDto>.Filter.Eq(_ => _.Key, statsDeleted)).ToList().Select(_ => (long)_.Value))
                     .ToArray();
                 stats.Deleted = deletedItems.Any() ? deletedItems.Sum() : 0;
 

--- a/src/Hangfire.Mongo/MongoMonitoringApi.cs
+++ b/src/Hangfire.Mongo/MongoMonitoringApi.cs
@@ -5,6 +5,7 @@ using Hangfire.Common;
 using Hangfire.Mongo.Database;
 using Hangfire.Mongo.Dto;
 using Hangfire.Mongo.PersistentJobQueue;
+using Hangfire.Mongo.StateHandlers;
 using Hangfire.States;
 using Hangfire.Storage;
 using Hangfire.Storage.Monitoring;
@@ -93,12 +94,12 @@ namespace Hangfire.Mongo
                     return null;
 
                 var history = job.StateHistory.Select(x => new StateHistoryDto
-                    {
-                        StateName = x.Name,
-                        CreatedAt = x.CreatedAt,
-                        Reason = x.Reason,
-                        Data = x.Data
-                    })
+                {
+                    StateName = x.Name,
+                    CreatedAt = x.CreatedAt,
+                    Reason = x.Reason,
+                    Data = x.Data
+                })
                     .Reverse()
                     .ToList();
 
@@ -112,7 +113,7 @@ namespace Hangfire.Mongo
             });
         }
 
-        private static readonly string[] StatisticsStateNames = new []
+        private static readonly string[] StatisticsStateNames = new[]
         {
             EnqueuedState.StateName,
             FailedState.StateName,
@@ -295,22 +296,22 @@ namespace Hangfire.Mongo
 
         public IDictionary<DateTime, long> SucceededByDatesCount()
         {
-            return UseConnection(connection => GetTimelineStats(connection, "succeeded"));
+            return UseConnection(connection => GetTimelineStats(connection, State.Succeeded));
         }
 
         public IDictionary<DateTime, long> FailedByDatesCount()
         {
-            return UseConnection(connection => GetTimelineStats(connection, "failed"));
+            return UseConnection(connection => GetTimelineStats(connection, State.Failed));
         }
 
         public IDictionary<DateTime, long> HourlySucceededJobs()
         {
-            return UseConnection(connection => GetHourlyTimelineStats(connection, "succeeded"));
+            return UseConnection(connection => GetHourlyTimelineStats(connection, State.Succeeded));
         }
 
         public IDictionary<DateTime, long> HourlyFailedJobs()
         {
-            return UseConnection(connection => GetHourlyTimelineStats(connection, "failed"));
+            return UseConnection(connection => GetHourlyTimelineStats(connection, State.Failed));
         }
 
         private T UseConnection<T>(Func<HangfireDbContext, T> action)

--- a/src/Hangfire.Mongo/MongoSchema.cs
+++ b/src/Hangfire.Mongo/MongoSchema.cs
@@ -45,7 +45,7 @@
         /// Schema version 10
         /// </summary>
         Version10 = 10,
-        
+
         /// <summary>
         /// Schema version 11
         /// </summary>

--- a/src/Hangfire.Mongo/StateHandlers/DeletedStateHandler.cs
+++ b/src/Hangfire.Mongo/StateHandlers/DeletedStateHandler.cs
@@ -8,13 +8,13 @@ namespace Hangfire.Mongo.StateHandlers
     {
         public void Apply(ApplyStateContext context, IWriteOnlyTransaction transaction)
         {
-            transaction.InsertToList("deleted", context.BackgroundJob.Id);
-            transaction.TrimList("deleted", 0, 99);
+            transaction.InsertToList(State.Deleted, context.BackgroundJob.Id);
+            transaction.TrimList(State.Deleted, 0, 99);
         }
 
         public void Unapply(ApplyStateContext context, IWriteOnlyTransaction transaction)
         {
-            transaction.RemoveFromList("deleted", context.BackgroundJob.Id);
+            transaction.RemoveFromList(State.Deleted, context.BackgroundJob.Id);
         }
 
         public string StateName => DeletedState.StateName;

--- a/src/Hangfire.Mongo/StateHandlers/FailedStateHandler.cs
+++ b/src/Hangfire.Mongo/StateHandlers/FailedStateHandler.cs
@@ -10,12 +10,12 @@ namespace Hangfire.Mongo.StateHandlers
     {
         public void Apply(ApplyStateContext context, IWriteOnlyTransaction transaction)
         {
-            transaction.AddToSet("failed", context.BackgroundJob.Id, JobHelper.ToTimestamp(DateTime.UtcNow));
+            transaction.AddToSet(State.Failed, context.BackgroundJob.Id, JobHelper.ToTimestamp(DateTime.UtcNow));
         }
 
         public void Unapply(ApplyStateContext context, IWriteOnlyTransaction transaction)
         {
-            transaction.RemoveFromSet("failed", context.BackgroundJob.Id);
+            transaction.RemoveFromSet(State.Failed, context.BackgroundJob.Id);
         }
 
         public string StateName => FailedState.StateName;

--- a/src/Hangfire.Mongo/StateHandlers/ProcessingStateHandler.cs
+++ b/src/Hangfire.Mongo/StateHandlers/ProcessingStateHandler.cs
@@ -10,12 +10,12 @@ namespace Hangfire.Mongo.StateHandlers
     {
         public void Apply(ApplyStateContext context, IWriteOnlyTransaction transaction)
         {
-            transaction.AddToSet("processing", context.BackgroundJob.Id, JobHelper.ToTimestamp(DateTime.UtcNow));
+            transaction.AddToSet(State.Processing, context.BackgroundJob.Id, JobHelper.ToTimestamp(DateTime.UtcNow));
         }
 
         public void Unapply(ApplyStateContext context, IWriteOnlyTransaction transaction)
         {
-            transaction.RemoveFromSet("processing", context.BackgroundJob.Id);
+            transaction.RemoveFromSet(State.Processing, context.BackgroundJob.Id);
         }
 
         public string StateName => ProcessingState.StateName;

--- a/src/Hangfire.Mongo/StateHandlers/State.cs
+++ b/src/Hangfire.Mongo/StateHandlers/State.cs
@@ -1,0 +1,14 @@
+﻿namespace Hangfire.Mongo.StateHandlers
+{
+
+    internal class State
+    {
+        public const string Succeeded = "succeeded";
+
+        public const string Processing = "processing";
+
+        public const string Failed = "failed";
+
+        public const string Deleted = "deleted";
+    }
+}

--- a/src/Hangfire.Mongo/StateHandlers/SucceededStateHandler.cs
+++ b/src/Hangfire.Mongo/StateHandlers/SucceededStateHandler.cs
@@ -8,13 +8,13 @@ namespace Hangfire.Mongo.StateHandlers
     {
         public void Apply(ApplyStateContext context, IWriteOnlyTransaction transaction)
         {
-            transaction.InsertToList("succeeded", context.BackgroundJob.Id);
-            transaction.TrimList("succeeded", 0, 99);
+            transaction.InsertToList(State.Succeeded, context.BackgroundJob.Id);
+            transaction.TrimList(State.Succeeded, 0, 99);
         }
 
         public void Unapply(ApplyStateContext context, IWriteOnlyTransaction transaction)
         {
-            transaction.RemoveFromList("succeeded", context.BackgroundJob.Id);
+            transaction.RemoveFromList(State.Succeeded, context.BackgroundJob.Id);
         }
 
         public string StateName => SucceededState.StateName;


### PR DESCRIPTION
I needed some constants for those states. So I went with those provided by Hangfire.

Why didn't we do this sooner? What is the catch? Shouldn't we be doing it?