### PR TITLE
#139 fix(distributed lock) - Removing EventHandle optimization

### DIFF
--- a/src/Hangfire.Mongo/DistributedLock/MongoDistributedLock.cs
+++ b/src/Hangfire.Mongo/DistributedLock/MongoDistributedLock.cs
@@ -10,18 +10,10 @@ using MongoDB.Driver;
 namespace Hangfire.Mongo.DistributedLock
 {
     /// <summary>
-    /// Represents distibuted lock implementation for MongoDB
+    /// Represents distributed lock implementation for MongoDB
     /// </summary>
     internal sealed class MongoDistributedLock : IDisposable
     {
-
-        // EventWaitHandle is not supported on UNIX systems
-        // https://github.com/dotnet/coreclr/pull/1387
-        // Instead of using a compiler directive, we catch the
-        // exception and handles it. This way, when EventWaitHandle
-        // becomes available on UNIX, we will start working.
-        private static bool _isEventWaitHandleSupported = true;
-
         private static readonly ILog Logger = LogProvider.For<MongoDistributedLock>();
 
         private static readonly ThreadLocal<Dictionary<string, int>> AcquiredLocks
@@ -40,8 +32,6 @@ namespace Hangfire.Mongo.DistributedLock
         private bool _completed;
 
         private readonly object _lockObject = new object();
-
-        private string EventWaitHandleName => $@"{GetType().FullName}.{_resource}";
 
         /// <summary>
         /// Creates MongoDB distributed lock
@@ -152,30 +142,9 @@ namespace Hangfire.Mongo.DistributedLock
                     }
                     else
                     {
-                        EventWaitHandle eventWaitHandle = null;
                         var waitTime = (int)timeout.TotalMilliseconds / 10;
-                        if (_isEventWaitHandleSupported)
-                        {
-                            try
-                            {
-                                // Wait on the event. This allows us to be "woken" up sooner rather than later.
-                                // We wait in chunks as we need to "wake-up" from time to time and poll mongo,
-                                // in case that the lock was acquired on another machine or instance.
-                                eventWaitHandle = new EventWaitHandle(false, EventResetMode.AutoReset, EventWaitHandleName);
-                                eventWaitHandle.WaitOne(waitTime);
-                            }
-                            catch (PlatformNotSupportedException)
-                            {
-                                // See _isEventWaitHandleSupported definition for more info.
-                                _isEventWaitHandleSupported = false;
-                                eventWaitHandle = null;
-                            }
-                        }
-                        if (eventWaitHandle == null)
-                        {
-                            // Sleep for a while and then check if the lock has been released.
-                            Thread.Sleep(waitTime);
-                        }
+                        // Sleep for a while and then check if the lock has been released.
+                        Thread.Sleep(waitTime);
                         now = DateTime.Now;
                     }
                 }
@@ -207,22 +176,6 @@ namespace Hangfire.Mongo.DistributedLock
                 // Remove resource lock
                 _database.DistributedLock.DeleteOne(
                     Builders<DistributedLockDto>.Filter.Eq(_ => _.Resource, _resource));
-
-                if (_isEventWaitHandleSupported)
-                {
-                    try
-                    {
-                        if (EventWaitHandle.TryOpenExisting(EventWaitHandleName, out EventWaitHandle eventWaitHandler))
-                        {
-                            eventWaitHandler.Set();
-                        }
-                    }
-                    catch (PlatformNotSupportedException)
-                    {
-                        // See _isEventWaitHandleSupported definition for more info.
-                        _isEventWaitHandleSupported = false;
-                    }
-                }
             }
             catch (Exception ex)
             {
@@ -256,7 +209,7 @@ namespace Hangfire.Mongo.DistributedLock
             _heartbeatTimer = new Timer(state =>
             {
                 // Timer callback may be invoked after the Dispose method call,
-                // so we are using lock to avoid unsynchronized calls.
+                // so we are using lock to avoid un synchronized calls.
                 lock (_lockObject)
                 {
                     try


### PR DESCRIPTION
As we target observing capped collections for locks, I think its ok to remove this, until the other functionality is ready