### PR TITLE
Dirty fix for duplicate key exception when getting job hash data

### DIFF
--- a/src/Hangfire.Mongo/MongoConnection.cs
+++ b/src/Hangfire.Mongo/MongoConnection.cs
@@ -351,12 +351,15 @@ namespace Hangfire.Mongo
                 throw new ArgumentNullException(nameof(key));
             }
 
-            var result = Database
+            var result = new Dictionary<string, string>();
+
+            foreach (var hashDto in Database
                 .StateData
                 .OfType<HashDto>()
-                .Find(Builders<HashDto>.Filter.Eq(_ => _.Key, key))
-                .ToList()
-                .ToDictionary(x => x.Field, x => (string)x.Value);
+                .Find(Builders<HashDto>.Filter.Eq(_ => _.Key, key)).ToList())
+            {
+                result[hashDto.Field] = (string) hashDto.Value;
+            }
 
             return result.Count != 0 ? result : null;
         }


### PR DESCRIPTION
This solves the symptoms and the throwing of errors.

We need a better model for the job data which is in progress.