### PR TITLE
Use 'buildinfo' command instead of 'serverStatus' to get the server version.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 
-## What's New (03/09/2018)
+## What's New (28/10/2018)
+
+### v0.5.12
+- Using $dec and $inc operators for counters
+- Merging HashDto fields into one document
+- Deprecating  direct db access and queueproviders
+- Removed use of $slice (#151) 
 
 ### v0.5.11
 - Fixed duplicate key exception in advanced setups (#70)

--- a/src/Hangfire.Mongo.Sample.ASPNetCore/Hangfire.Mongo.Sample.ASPNetCore.csproj
+++ b/src/Hangfire.Mongo.Sample.ASPNetCore/Hangfire.Mongo.Sample.ASPNetCore.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <Description />
-    <Version>0.5.11</Version>
+    <Version>0.5.12</Version>
     <Description>MongoDB storage implementation for Hangfire (background job system for ASP.NET applications).</Description>
     <Copyright>Copyright © 2014-2017 Sergey Zwezdin, Martin Lobger, Jonas Gottschau</Copyright>
     <Authors>Sergey Zwezdin, Martin Lobger, Jonas Gottschau</Authors>

--- a/src/Hangfire.Mongo.Sample.NETCore/Hangfire.Mongo.Sample.NETCore.csproj
+++ b/src/Hangfire.Mongo.Sample.NETCore/Hangfire.Mongo.Sample.NETCore.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>Hangfire.Mongo.Sample.NETCore</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Hangfire.Mongo.Sample.NETCore</PackageId>
-    <Version>0.5.11</Version>
+    <Version>0.5.12</Version>
     <Description>MongoDB storage implementation for Hangfire (background job system for ASP.NET applications).</Description>
     <Copyright>Copyright © 2014-2017 Sergey Zwezdin, Martin Lobger, Jonas Gottschau</Copyright>
     <Authors>Sergey Zwezdin, Martin Lobger, Jonas Gottschau</Authors>

--- a/src/Hangfire.Mongo.Sample/Properties/AssemblyInfo.cs
+++ b/src/Hangfire.Mongo.Sample/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("0.5.11")]
-[assembly: AssemblyFileVersion("0.5.11")]
+[assembly: AssemblyVersion("0.5.12")]
+[assembly: AssemblyFileVersion("0.5.12")]

--- a/src/Hangfire.Mongo.Tests/Properties/AssemblyInfo.cs
+++ b/src/Hangfire.Mongo.Tests/Properties/AssemblyInfo.cs
@@ -34,6 +34,6 @@ using Xunit;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.5.11")]
-[assembly: AssemblyFileVersion("0.5.11")]
-[assembly: AssemblyInformationalVersion("0.5.11")]
+[assembly: AssemblyVersion("0.5.12")]
+[assembly: AssemblyFileVersion("0.5.12")]
+[assembly: AssemblyInformationalVersion("0.5.12")]

--- a/src/Hangfire.Mongo/Hangfire.Mongo.csproj
+++ b/src/Hangfire.Mongo/Hangfire.Mongo.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>0.5.11</VersionPrefix>
+    <VersionPrefix>0.5.12</VersionPrefix>
     <TargetFrameworks>net46;net45;netstandard1.5</TargetFrameworks>
     <NoWarn>$(NoWarn);CS0618</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -22,7 +22,13 @@
     <owners>Sergey Zwezdin</owners>
     <Description>MongoDB storage implementation for Hangfire (background job system for ASP.NET applications).</Description>
     <PackageTags>Hangfire AspNet OWIN MongoDB Long-Running Background Fire-And-Forget Delayed Recurring Tasks Jobs Scheduler Threading Queues</PackageTags>
-    <PackageReleaseNotes>0.5.11
+    <PackageReleaseNotes>0.5.12
+- Using $dec and $inc operators for counters
+- Merging HashDto fields into one document
+- Deprecating  direct db access and queueproviders
+- Removed use of $slice (#151) 
+
+0.5.11
 - Fixed duplicate key exception in advanced setups (#70)
 - Fixed DeadLock on concurrent environment (#139)
 - Update to latest Hangfire

--- a/src/Hangfire.Mongo/Migration/Strategies/MongoMigrationStrategyBase.cs
+++ b/src/Hangfire.Mongo/Migration/Strategies/MongoMigrationStrategyBase.cs
@@ -171,7 +171,7 @@ namespace Hangfire.Mongo.Migration.Strategies
                 }
             });
 
-            var serverStatus = database.RunCommand<BsonDocument>(new BsonDocument("serverStatus", 1));
+            var serverStatus = database.RunCommand<BsonDocument>(new BsonDocument("buildinfo", 1));
             if (serverStatus.Contains("version"))
             {
                 var version = Version.Parse(serverStatus["version"].AsString);

--- a/src/Hangfire.Mongo/Properties/AssemblyInfo.cs
+++ b/src/Hangfire.Mongo/Properties/AssemblyInfo.cs
@@ -29,7 +29,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.5.11")]
-[assembly: AssemblyFileVersion("0.5.11")]
-[assembly: AssemblyInformationalVersion("0.5.11")]
+[assembly: AssemblyVersion("0.5.12")]
+[assembly: AssemblyFileVersion("0.5.12")]
+[assembly: AssemblyInformationalVersion("0.5.12")]
 [assembly: InternalsVisibleTo("Hangfire.Mongo.Tests")]


### PR DESCRIPTION
Because the 'buildinfo' command does not require root privileges.