### PR TITLE
Fix MongoMigrationStrategyDrop

### DIFF
--- a/src/Hangfire.Mongo/Migration/Strategies/MongoMigrationStrategyDrop.cs
+++ b/src/Hangfire.Mongo/Migration/Strategies/MongoMigrationStrategyDrop.cs
@@ -19,7 +19,7 @@ namespace Hangfire.Mongo.Migration.Strategies
 
         protected override void Migrate(MongoSchema fromSchema, MongoSchema toSchema)
         {
-            base.Execute(MongoSchema.None, toSchema);
+            base.Migrate(MongoSchema.None, toSchema);
         }
 
 


### PR DESCRIPTION
Fix MongoMigrationStrategyDrop.Migrate calling base.Execute which resulted in an endless recursive loop