### PR TITLE
Fix requeued job (manual or autoretry) being shown as "aborted" when using multiple hangfire servers (issue #167)

### DIFF
--- a/src/Hangfire.Mongo/MongoMonitoringApi.cs
+++ b/src/Hangfire.Mongo/MongoMonitoringApi.cs
@@ -446,7 +446,7 @@ namespace Hangfire.Mongo
             List<JobSummary> joinedJobs = jobsFiltered
                 .Select(job =>
                 {
-                    var state = job.StateHistory.FirstOrDefault(s => s.Name == job.StateName);
+                    var state = job.StateHistory.LastOrDefault(s => s.Name == job.StateName);
                     return new JobSummary
                     {
                         Id = job.Id.ToString(),
@@ -498,8 +498,7 @@ namespace Hangfire.Mongo
             var joinedJobs = jobs
                 .Select(job =>
                 {
-                    var state = job.StateHistory.FirstOrDefault(s => s.Name == stateName);
-
+                    var state = job.StateHistory.LastOrDefault(s => s.Name == stateName);
                     return new JobSummary
                     {
                         Id = job.Id.ToString(),


### PR DESCRIPTION
This PR fix requeued job (manual or autoretry) being shown as "aborted" when using multiple hangfire servers (#167).
Unit test added as well.