### PR TITLE
Fix #191: Catch OperationCanceledException to hide error log

### DIFF
--- a/src/Hangfire.Mongo/MongoNotificationObserver.cs
+++ b/src/Hangfire.Mongo/MongoNotificationObserver.cs
@@ -85,6 +85,7 @@ namespace Hangfire.Mongo
                         }
                     }
                 }
+                catch(OperationCanceledException) {}
                 catch (Exception e)
                 {
                     Logger.Error($"Error observing notifications\r\n{e}");


### PR DESCRIPTION
Added a catch for OperationCanceledException to prevent the raising of an error log message.

We expect the underlying Mongo Core code to throw the exception in order to exit execution when the CancellationToken is requesting cancellation. So with this in mind this particular case wouldn't be an error and (I don't feel) is worth raising any logs for.