### PR TITLE
Explicitly set discriminators because filters rely on them

### DIFF
--- a/src/Hangfire.Mongo/Dto/BaseJobDto.cs
+++ b/src/Hangfire.Mongo/Dto/BaseJobDto.cs
@@ -4,7 +4,7 @@ using MongoDB.Bson.Serialization.Attributes;
 namespace Hangfire.Mongo.Dto
 {
 #pragma warning disable 1591
-    [BsonDiscriminator(RootClass = true)]
+    [BsonDiscriminator(nameof(BaseJobDto), RootClass = true)]
     [BsonKnownTypes(
         typeof(ExpiringJobDto),
         typeof(KeyJobDto),

--- a/src/Hangfire.Mongo/Dto/CounterDto.cs
+++ b/src/Hangfire.Mongo/Dto/CounterDto.cs
@@ -3,6 +3,7 @@
 namespace Hangfire.Mongo.Dto
 {
 #pragma warning disable 1591
+    [BsonDiscriminator(nameof(CounterDto))]
     public class CounterDto : KeyJobDto
     {
         [BsonElement(nameof(Value))]

--- a/src/Hangfire.Mongo/Dto/ExpiringJobDto.cs
+++ b/src/Hangfire.Mongo/Dto/ExpiringJobDto.cs
@@ -4,7 +4,7 @@ using MongoDB.Bson.Serialization.Attributes;
 namespace Hangfire.Mongo.Dto
 {
 #pragma warning disable 1591
-    
+    [BsonDiscriminator(nameof(ExpiringJobDto))]
     public abstract class ExpiringJobDto : BaseJobDto
     {
         [BsonElement(nameof(ExpireAt))]

--- a/src/Hangfire.Mongo/Dto/HashDto.cs
+++ b/src/Hangfire.Mongo/Dto/HashDto.cs
@@ -4,6 +4,7 @@ using MongoDB.Bson.Serialization.Attributes;
 namespace Hangfire.Mongo.Dto
 {
 #pragma warning disable 1591
+    [BsonDiscriminator(nameof(HashDto))]
     public class HashDto : KeyJobDto
     {
         [BsonElement(nameof(Fields))]

--- a/src/Hangfire.Mongo/Dto/JobDto.cs
+++ b/src/Hangfire.Mongo/Dto/JobDto.cs
@@ -5,6 +5,7 @@ using MongoDB.Bson.Serialization.Attributes;
 namespace Hangfire.Mongo.Dto
 {
 #pragma warning disable 1591
+    [BsonDiscriminator(nameof(JobDto))]
     public class JobDto : ExpiringJobDto
     {
         [BsonElement(nameof(StateName))]

--- a/src/Hangfire.Mongo/Dto/KeyJobDto.cs
+++ b/src/Hangfire.Mongo/Dto/KeyJobDto.cs
@@ -3,7 +3,7 @@
 namespace Hangfire.Mongo.Dto
 {
 #pragma warning disable 1591
-
+    [BsonDiscriminator(nameof(KeyJobDto))]
     public abstract class KeyJobDto : ExpiringJobDto
     {
         [BsonElement(nameof(Key))]

--- a/src/Hangfire.Mongo/Dto/ListDto.cs
+++ b/src/Hangfire.Mongo/Dto/ListDto.cs
@@ -3,6 +3,7 @@
 namespace Hangfire.Mongo.Dto
 {
 #pragma warning disable 1591
+    [BsonDiscriminator(nameof(ListDto))]
     public class ListDto : ExpiringJobDto
     {
         [BsonElement(nameof(Item))]

--- a/src/Hangfire.Mongo/Dto/SetDto.cs
+++ b/src/Hangfire.Mongo/Dto/SetDto.cs
@@ -3,6 +3,7 @@
 namespace Hangfire.Mongo.Dto
 {
 #pragma warning disable 1591
+    [BsonDiscriminator(nameof(SetDto))]
     public class SetDto : KeyJobDto
     {
         [BsonElement(nameof(Score))]


### PR DESCRIPTION
Hello Sergey, Martin, Jonas,

After updating to 0.4.1 (and up to 0.6.2), my team noticed jobs weren't being picked up and I traced it down to a filtering problem from `MongoWriteOnlyTransaction`, because of bad discriminators on `Job*` DTOs. This PR solves the problem with as little modifications and risk as possible, by explicitly setting discriminators to expected values.

### TLDR

**The environment**

The main entities our app works with come from plugins, so Mongo Driver's default conventions and discriminators usually aren't enough to cover our use case. That's why we have our own (scalar) discriminator convention, which uses types' `FullName`s instead of just `Name`s.

**The problem**

Even though Hangfire.Mongo uses the hierarchical convention, the custom one we're using caused `Job*` objects' discriminators to be serialized as e.g. `_t: ["Hangfire.Mongo.Dto.BaseJobDto", "Hangfire.Mongo.Dto.ExpiringJobDto", "Hangfire.Mongo.Dto.JobDto"]` instead of `_t: ["BaseJobDto", "ExpiringJobDto", "JobDto"]`, causing filters like `..."_t" : "JobDto"...` from `MongoWriteOnlyTransaction` to not find anything.

**The solution**

We could have fixed this on our side too, just avoiding anything belonging to the Hangfire namespace, but then others doing similar things would have to spend time tracking it down and introducing such a specific hack. The current solution seems good enough to me, as it doesn't break anything and the existing code already heavily relies on it being like that.

A more flexible, but also more complicated, risky and less performant solution would be to refactor filter building code to ask the `BsonSerializer` for the discriminators. But I, pragmatically and a bit selfishly, opted for the simpler and safer one hoping for a quick merge and publish, cause my team is waiting on it for our upcoming release :)