### PR TITLE
Cleanup expired DistributedLock after each wait iteration

### DIFF
--- a/src/Hangfire.Mongo/DistributedLock/MongoDistributedLock.cs
+++ b/src/Hangfire.Mongo/DistributedLock/MongoDistributedLock.cs
@@ -189,6 +189,8 @@ namespace Hangfire.Mongo.DistributedLock
                         // unfortunately there doesn't appear to be a more specific exception type to catch.
                         now = _mutex.Wait(_resource, CalculateTimeout(timeout));
                     }
+
+                    Cleanup();
                 }
 
                 if (!isLockAcquired)


### PR DESCRIPTION
This PR fixes case when the application crashed, then immediately restarted - can't acquire a lock, even if it has expired.