### PR TITLE
Add support for specifying the database name in the connection string

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 
-## What's New (14/08/2019)
+## What's New (15/11/2019)
+
+### v0.6.6
+- Add support for specifying the database name in the connection string (#219)
+
 ### v0.6.5
 - Cleanup expired DistributedLock after each wait iteration (#217)
 - Make extracting mongodb version more resilient

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ PM> Install-Package Hangfire.Mongo
 ## Usage ASP.NET
 
 ```csharp
-GlobalConfiguration.Configuration.UseMongoStorage("mongodb://localhost", "ApplicationDatabase");
+GlobalConfiguration.Configuration.UseMongoStorage("mongodb://localhost/ApplicationDatabase");
 app.UseHangfireServer();
 app.UseHangfireDashboard();
 ```
@@ -31,7 +31,7 @@ public void ConfigureServices(IServiceCollection services)
     // Add framework services.
     services.AddHangfire(config =>
     {
-        config.UseMongoStorage("mongodb://localhost", "ApplicationDatabase");
+        config.UseMongoStorage("mongodb://localhost/ApplicationDatabase");
     });
 }
 ```
@@ -43,7 +43,7 @@ To use custom prefix for collections names specify it on Hangfire setup:
 ```csharp
 public void Configuration(IAppBuilder app)
 {
-    GlobalConfiguration.Configuration.UseMongoStorage("mongodb://localhost", "ApplicationDatabase",
+    GlobalConfiguration.Configuration.UseMongoStorage("mongodb://localhost/ApplicationDatabase",
         new MongoStorageOptions { Prefix = "custom" } );
 
     app.UseHangfireServer();
@@ -90,7 +90,7 @@ public void Configuration(IAppBuilder app)
         // ...
         MigrationOptions = migrationOptions
     };
-    GlobalConfiguration.Configuration.UseMongoStorage("<connection string>", "<database name>", storageOptions);
+    GlobalConfiguration.Configuration.UseMongoStorage("<connection string with database name>", storageOptions);
 
     app.UseHangfireServer();
     app.UseHangfireDashboard();

--- a/src/Hangfire.Mongo.Sample.ASPNetCore/Startup.cs
+++ b/src/Hangfire.Mongo.Sample.ASPNetCore/Startup.cs
@@ -41,7 +41,7 @@ namespace Hangfire.Mongo.Sample.ASPNetCore
                 };
                 //config.UseLogProvider(new FileLogProvider());
                 config.UseColouredConsoleLogProvider(LogLevel.Trace);
-                config.UseMongoStorage(new MongoClient(connectionString), "hangfire-mongo-sample-aspnetcore", migrationOptions);
+                config.UseMongoStorage(connectionString, migrationOptions);
             });
             services.AddMvc();
 

--- a/src/Hangfire.Mongo.Sample.ASPNetCore/appsettings.json
+++ b/src/Hangfire.Mongo.Sample.ASPNetCore/appsettings.json
@@ -1,6 +1,6 @@
 ﻿{
   "ConnectionStrings": {
-    "DefaultConnection": "mongodb://localhost"
+    "DefaultConnection": "mongodb://localhost/hangfire-mongo-sample-aspnetcore"
   },
   "Logging": {
     "IncludeScopes": false,

--- a/src/Hangfire.Mongo.Sample/App_Start/Startup.Hangfire.cs
+++ b/src/Hangfire.Mongo.Sample/App_Start/Startup.Hangfire.cs
@@ -18,7 +18,7 @@ namespace Hangfire.Mongo.Sample
                     BackupStrategy = MongoBackupStrategy.Collections
                 }
             };
-            GlobalConfiguration.Configuration.UseMongoStorage(connectionString, "hangfire-mongo-sample", migrationOptions);
+            GlobalConfiguration.Configuration.UseMongoStorage(connectionString, migrationOptions);
             //GlobalConfiguration.Configuration.UseMongoStorage(new MongoClientSettings
             //{
             //    // ...

--- a/src/Hangfire.Mongo.Sample/Web.config
+++ b/src/Hangfire.Mongo.Sample/Web.config
@@ -5,7 +5,7 @@
   -->
 <configuration>
   <connectionStrings>
-    <add name="DefaultConnection" connectionString="mongodb://localhost" />
+    <add name="DefaultConnection" connectionString="mongodb://localhost/hangfire-mongo-sample" />
   </connectionStrings>
   <appSettings>
     <add key="webpages:Version" value="3.0.0.0" />

--- a/src/Hangfire.Mongo/MongoBootstrapperConfigurationExtensions.cs
+++ b/src/Hangfire.Mongo/MongoBootstrapperConfigurationExtensions.cs
@@ -53,9 +53,23 @@ namespace Hangfire.Mongo
         /// Configure Hangfire to use MongoDB storage
         /// </summary>
         /// <param name="configuration">Configuration</param>
+        /// <param name="connectionString">Connection string for Mongo database, for example 'mongodb://username:password@host:port/database'</param>
+        /// <remarks>The connection string must include the database name</remarks>
+        /// <returns></returns>
+        public static MongoStorage UseMongoStorage(this IGlobalConfiguration configuration,
+            string connectionString)
+        {
+            return UseMongoStorage(configuration, connectionString, new MongoStorageOptions());
+        }
+
+        /// <summary>
+        /// Configure Hangfire to use MongoDB storage
+        /// </summary>
+        /// <param name="configuration">Configuration</param>
         /// <param name="connectionString">Connection string for Mongo database, for example 'mongodb://username:password@host:port'</param>
         /// <param name="databaseName">Name of database at Mongo server</param>
         /// <returns></returns>
+        [Obsolete("Please use `UseMongoStorage(this IGlobalConfiguration configuration, string connectionString)` instead, providing the database name in the connection string.")]
         public static MongoStorage UseMongoStorage(this IGlobalConfiguration configuration,
             string connectionString,
             string databaseName)
@@ -67,10 +81,33 @@ namespace Hangfire.Mongo
         /// Configure Hangfire to use MongoDB storage
         /// </summary>
         /// <param name="configuration">Configuration</param>
+        /// <param name="connectionString">Connection string for Mongo database, for example 'mongodb://username:password@host:port/database'</param>
+        /// <param name="storageOptions">Storage options</param>
+        /// <exception cref="ArgumentException">Thrown if the connection string does not include the database name</exception>
+        /// <returns></returns>
+        public static MongoStorage UseMongoStorage(this IGlobalConfiguration configuration,
+            string connectionString,
+            MongoStorageOptions storageOptions)
+        {
+            var mongoUrlBuilder = new MongoUrlBuilder(connectionString);
+            var databaseName = mongoUrlBuilder.DatabaseName;
+            if (string.IsNullOrEmpty(databaseName))
+            {
+                throw new ArgumentException("The connection string must include the database name, see https://docs.mongodb.com/manual/reference/connection-string/", nameof(connectionString));
+            }
+            var mongoClientSettings = MongoClientSettings.FromConnectionString(connectionString);
+            return UseMongoStorage(configuration, mongoClientSettings, databaseName, storageOptions);
+        }
+
+        /// <summary>
+        /// Configure Hangfire to use MongoDB storage
+        /// </summary>
+        /// <param name="configuration">Configuration</param>
         /// <param name="connectionString">Connection string for Mongo database, for example 'mongodb://username:password@host:port'</param>
         /// <param name="databaseName">Name of database at Mongo server</param>
         /// <param name="storageOptions">Storage options</param>
         /// <returns></returns>
+        [Obsolete("Please use `UseMongoStorage(this IGlobalConfiguration configuration, string connectionString, MongoStorageOptions storageOptions)` instead, providing the database name in the connection string.")]
         public static MongoStorage UseMongoStorage(this IGlobalConfiguration configuration,
             string connectionString,
             string databaseName,
@@ -113,7 +150,7 @@ namespace Hangfire.Mongo
 
             return storage;
         }
-        
+
         /// <summary>
         /// Configure Hangfire to use MongoDB storage
         /// </summary>


### PR DESCRIPTION
I added the `[Obsolete]` attribute on the `UseMongoStorage` methods taking both a connection string and a database name.