### PR TITLE
Implement JobStorageConnection.GetFirstByLowestScoreFromSet's batch get version

### DIFF
--- a/src/Hangfire.Mongo/MongoConnection.cs
+++ b/src/Hangfire.Mongo/MongoConnection.cs
@@ -253,6 +253,11 @@ namespace Hangfire.Mongo
 
         public override string GetFirstByLowestScoreFromSet(string key, double fromScore, double toScore)
         {
+            return GetFirstByLowestScoreFromSet(key, fromScore, toScore, 1).FirstOrDefault();
+        }
+
+        public override List<string> GetFirstByLowestScoreFromSet(string key, double fromScore, double toScore, int count)
+        {
             if (key == null)
             {
                 throw new ArgumentNullException(nameof(key));
@@ -262,7 +267,7 @@ namespace Hangfire.Mongo
             {
                 throw new ArgumentException("The `toScore` value must be higher or equal to the `fromScore` value.");
             }
-            
+
             return _dbContext
                 .JobGraph
                 .OfType<SetDto>()
@@ -271,7 +276,8 @@ namespace Hangfire.Mongo
                       Builders<SetDto>.Filter.Lte(_ => _.Score, toScore))
                 .SortBy(_ => _.Score)
                 .Project(_ => _.Value)
-                .FirstOrDefault();
+                .Limit(count)
+                .ToList();
         }
 
         public override void SetRangeInHash(string key, IEnumerable<KeyValuePair<string, string>> keyValuePairs)


### PR DESCRIPTION
Implement `JobStorageConnection.GetFirstByLowestScoreFromSet's` batch get version. It can reduce the time that get the recurring jobs id. 
In my case, I have thousands of recurring job, they would triggered same time, but the max delay time of triggered would be ten miniutes. But when i add the implementation of  batch get method. the max delay time was significantly reduce.
You can click [this](https://github.com/HangfireIO/Hangfire/search?q=IsBatchingAvailable&unscoped_q=IsBatchingAvailable) to see why the batch get version can reduce the recurring job triggered delay time