### PR TITLE
Release v0.7.19

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,12 @@
 
 ## What's New (June. 7th. 2020)
 
+### v0.7.19
+- Update to latest Hangfire.Core (v1.7.19)
+- Update to latest Mongo drivers (v2.11.6)
+- Simplify semaphore logic and support more than 64 waithandles (#264)
+- Fixed issue caused by StringIdStoredAsObjectIdConvention() mongo convention (#267)
+
 ### v0.7.17
 - Update to latest Hangfire.Core (v1.7.17)
 - Update to latest Mongo drivers (v2.11.4)

--- a/src/Hangfire.Mongo.Sample.ASPNetCore/Hangfire.Mongo.Sample.ASPNetCore.csproj
+++ b/src/Hangfire.Mongo.Sample.ASPNetCore/Hangfire.Mongo.Sample.ASPNetCore.csproj
@@ -20,11 +20,11 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="bootstrap" Version="4.5.3" />
-    <PackageReference Include="Hangfire.AspNetCore" Version="1.7.17" />
-    <PackageReference Include="Hangfire.Core" Version="1.7.17" />
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.7.19" />
+    <PackageReference Include="Hangfire.Core" Version="1.7.19" />
     <PackageReference Include="jquery" Version="3.5.1" />
-    <PackageReference Include="MongoDB.Driver" Version="2.11.4" />
+    <PackageReference Include="MongoDB.Driver" Version="2.11.6" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Hangfire.Mongo.Sample.ASPNetCore/Hangfire.Mongo.Sample.ASPNetCore.csproj
+++ b/src/Hangfire.Mongo.Sample.ASPNetCore/Hangfire.Mongo.Sample.ASPNetCore.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Description />
-    <Version>0.7.17</Version>
+    <Version>0.7.19</Version>
     <Description>MongoDB storage implementation for Hangfire (background job system for ASP.NET applications).</Description>
     <Copyright>Copyright © 2014-2019 Sergey Zwezdin, Martin Lobger, Jonas Gottschau</Copyright>
     <Authors>Sergey Zwezdin, Martin Lobger, Jonas Gottschau</Authors>

--- a/src/Hangfire.Mongo.Sample.ASPNetCore/Startup.cs
+++ b/src/Hangfire.Mongo.Sample.ASPNetCore/Startup.cs
@@ -59,6 +59,7 @@ namespace Hangfire.Mongo.Sample.ASPNetCore
             var options = new BackgroundJobServerOptions {Queues = new[] {"default", "notDefault"}};
             
             app.UseHangfireServer(options);
+            
             app.UseHangfireDashboard();
             app.UseDeveloperExceptionPage();
             app.UseBrowserLink();

--- a/src/Hangfire.Mongo.Sample.NETCore/Hangfire.Mongo.Sample.NETCore.csproj
+++ b/src/Hangfire.Mongo.Sample.NETCore/Hangfire.Mongo.Sample.NETCore.csproj
@@ -18,7 +18,7 @@
     <ProjectReference Include="..\Hangfire.Mongo\Hangfire.Mongo.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Hangfire.Core" Version="1.7.17" />
-    <PackageReference Include="MongoDB.Driver" Version="2.11.4" />
+    <PackageReference Include="Hangfire.Core" Version="1.7.19" />
+    <PackageReference Include="MongoDB.Driver" Version="2.11.6" />
   </ItemGroup>
 </Project>

--- a/src/Hangfire.Mongo.Sample.NETCore/Hangfire.Mongo.Sample.NETCore.csproj
+++ b/src/Hangfire.Mongo.Sample.NETCore/Hangfire.Mongo.Sample.NETCore.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>Hangfire.Mongo.Sample.NETCore</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Hangfire.Mongo.Sample.NETCore</PackageId>
-    <Version>0.7.17</Version>
+    <Version>0.7.19</Version>
     <Description>MongoDB storage implementation for Hangfire (background job system for ASP.NET applications).</Description>
     <Copyright>Copyright © 2014-2019 Sergey Zwezdin, Martin Lobger, Jonas Gottschau</Copyright>
     <Authors>Sergey Zwezdin, Martin Lobger, Jonas Gottschau</Authors>

--- a/src/Hangfire.Mongo.Tests/Hangfire.Mongo.Tests.csproj
+++ b/src/Hangfire.Mongo.Tests/Hangfire.Mongo.Tests.csproj
@@ -26,9 +26,9 @@
     <ProjectReference Include="../Hangfire.Mongo/Hangfire.Mongo.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-    <PackageReference Include="Moq" Version="4.14.7" />
+    <PackageReference Include="Moq" Version="4.16.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>

--- a/src/Hangfire.Mongo/Dto/ServerDto.cs
+++ b/src/Hangfire.Mongo/Dto/ServerDto.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 
 namespace Hangfire.Mongo.Dto
@@ -8,6 +9,7 @@ namespace Hangfire.Mongo.Dto
     {
         [BsonId]
         [BsonElement("_id")]
+        [BsonRepresentation(BsonType.String)]
         public string Id { get; set; }
 
         [BsonElement(nameof(WorkerCount))]

--- a/src/Hangfire.Mongo/Hangfire.Mongo.csproj
+++ b/src/Hangfire.Mongo/Hangfire.Mongo.csproj
@@ -22,13 +22,11 @@
     <owners>Sergey Zwezdin, Jonas Gottschau</owners>
     <Description>MongoDB storage implementation for Hangfire (background job system for ASP.NET applications).</Description>
     <PackageTags>Hangfire AspNet OWIN MongoDB Long-Running Background Fire-And-Forget Delayed Recurring Tasks Jobs Scheduler Threading Queues</PackageTags>
-    <PackageReleaseNotes>0.7.17
-      - Update to latest Hangfire.Core (v1.7.17)
-      - Update to latest Mongo drivers (v2.11.4)
-      - Only targeting netstandard2.0
-      - Remove ASP.NET sample
-      - Fix collection backup requires dbadmin role (#253)
-      - Adds bypass migration flag to MongoStorageOptions (#256)
+    <PackageReleaseNotes>0.7.19
+      - Update to latest Hangfire.Core (v1.7.19)
+      - Update to latest Mongo drivers (v2.11.6)
+      - Simplify semaphore logic and support more than 64 waithandles (#264)
+      - Fixed issue caused by StringIdStoredAsObjectIdConvention() mongo convention (#267)
 </PackageReleaseNotes>
     <!--<PackageLicenseUrl>https://raw.githubusercontent.com/sergun/Hangfire.Mongo/master/LICENSE</PackageLicenseUrl>-->
     <PackageProjectUrl>https://github.com/sergeyzwezdin/Hangfire.Mongo</PackageProjectUrl>
@@ -38,8 +36,8 @@
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Hangfire.Core" Version="1.7.17" />
-    <PackageReference Include="MongoDB.Driver" Version="2.11.4" />
+    <PackageReference Include="Hangfire.Core" Version="1.7.19" />
+    <PackageReference Include="MongoDB.Driver" Version="2.11.6" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 </Project>

--- a/src/Hangfire.Mongo/Hangfire.Mongo.csproj
+++ b/src/Hangfire.Mongo/Hangfire.Mongo.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>0.7.17</VersionPrefix>
+    <VersionPrefix>0.7.19</VersionPrefix>
     <TargetFramework>netstandard2.0</TargetFramework>
     <NoWarn>$(NoWarn);CS0618</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Hangfire.Mongo/JobQueueSemaphore.cs
+++ b/src/Hangfire.Mongo/JobQueueSemaphore.cs
@@ -99,8 +99,8 @@ namespace Hangfire.Mongo
                 _pool.TryGetValue(queue, out count);
                 count += 1;
                 _pool[queue] = count;
-                _releasedSignal.Set();
             }
+            _releasedSignal.Set();
 
             if (Logger.IsTraceEnabled())
             {

--- a/src/Hangfire.Mongo/MongoConnection.cs
+++ b/src/Hangfire.Mongo/MongoConnection.cs
@@ -196,7 +196,8 @@ namespace Hangfire.Mongo
                 [nameof(ServerDto.LastHeartbeat)] = DateTime.UtcNow
             });
 
-            _dbContext.Server.UpdateOne(new BsonDocument("_id", serverId), set, new UpdateOptions {IsUpsert = true});
+            var filter = Builders<ServerDto>.Filter.Eq(s => s.Id, serverId);
+            _dbContext.Server.UpdateOne(filter, set, new UpdateOptions {IsUpsert = true});
         }
 
         public override void RemoveServer(string serverId)


### PR DESCRIPTION
- Update to latest Hangfire.Core (v1.7.19)
- Update to latest Mongo drivers (v2.11.6)
- Simplify semaphore logic and support more than 64 waithandles (#264)
- Fixed issue caused by StringIdStoredAsObjectIdConvention() mongo convention (#267)