### PR TITLE
Heartbeat method should throw a BackgroundServerGoneException when no servers exist for an update

### DIFF
--- a/src/Hangfire.Mongo.Tests/MongoConnectionFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoConnectionFacts.cs
@@ -585,6 +585,15 @@ namespace Hangfire.Mongo.Tests
         }
 
         [Fact, CleanDatabase]
+        public void Heartbeat_ThrowsBackgroundServerGoneException_WhenGivenServerDoesNotExist()
+        {
+            var serverId = Guid.NewGuid().ToString();
+
+            Assert.Throws<BackgroundServerGoneException>(
+                () => _connection.Heartbeat(serverId));
+        }
+
+        [Fact, CleanDatabase]
         public void Heartbeat_UpdatesLastHeartbeat_OfTheServerWithGivenId()
         {
             _dbContext.Server.InsertOne(new ServerDto


### PR DESCRIPTION
As of Hangfire version 1.7.0 the storage [`Heartbeat`](https://github.com/sergeyzwezdin/Hangfire.Mongo/blob/d5b921874ef341c6f56a88a58ab0cc35eca7856e/src/Hangfire.Mongo/MongoConnection.cs#L218) method should throw a `BackgroundServerGoneException` when no servers respond to a heartbeat in order to allow [Hangfire.Server.ServerHeartbeatProcess](https://github.com/HangfireIO/Hangfire/blob/b5fabd9e544bdfcbf4eabfb8bde33ba1e30ac4d1/src/Hangfire.Core/Server/ServerHeartbeatProcess.cs#L65) to automatically restart the failed servers.

This should fix a known [issue](https://github.com/HangfireIO/Hangfire/issues/1123) with servers disappearing, that I've experienced as well using the latest Hangfire.Mongo v0.7.22 

[Example](https://github.com/HangfireIO/Hangfire/blob/b5fabd9e544bdfcbf4eabfb8bde33ba1e30ac4d1/src/Hangfire.SqlServer/SqlServerConnection.cs#L483) of an implementation in the official Hangfire repo.