### PR TITLE
Simplify tests

### DIFF
--- a/src/Hangfire.Mongo.Tests/Hangfire.Mongo.Tests.csproj
+++ b/src/Hangfire.Mongo.Tests/Hangfire.Mongo.Tests.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Testcontainers.MongoDb" Version="4.8.1" />
+    <PackageReference Include="Testcontainers.Xunit" Version="4.8.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all" />
     <PackageReference Include="xunit" Version="2.9.3" />
   </ItemGroup>


### PR DESCRIPTION
## Test project
* Use globbing for copying the migration zip files
* Update test dependencies to their latest version
* Remove the transitive Microsoft.Extensions.Logging.Abstractions package
* Remove the Service guid, see https://github.com/microsoft/vstest/issues/472#issuecomment-378811616

## Test code
* Use Testcontainers.Xunit to simplify MongoIntegrationTestFixture
* Get diagnostic logs through the message sink
* Better error handling in case the container initialization fails