### PR TITLE
moves job history to its own collection for better scalability

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,12 @@
 
 ## Change log
 
+### 1.13.0
+- BREAKING: Remove StateHistory from JobDto and move to separate collection for improved performance and scalability
+- BREAKING: Drop net472 target framework, now targeting netstandard2.1 and net48
+- Add migration lock heartbeat timer to prevent timeout during long-running migrations
+- Update to MongoDB.Driver 3.6.0
+
 ### 1.12.2
 - Update to Hangfire.Core 1.8.22
 - Fixes IsMasterUtcDateTimeStrategy for cosmosdb is unix timestamp. (#436)

--- a/src/Hangfire.Mongo.Sample.ASPNetCore/Hangfire.Mongo.Sample.ASPNetCore.csproj
+++ b/src/Hangfire.Mongo.Sample.ASPNetCore/Hangfire.Mongo.Sample.ASPNetCore.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Description />
     <Description>MongoDB storage implementation for Hangfire (background job system for ASP.NET applications).</Description>
     <Copyright>Copyright © 2014-2019 Sergey Zwezdin, Martin Lobger, Jonas Gottschau</Copyright>
@@ -23,9 +23,9 @@
     <PackageReference Include="Hangfire.AspNetCore" Version="1.8.22" />
     <PackageReference Include="Hangfire.Core" Version="1.8.22" />
     <PackageReference Include="jquery" Version="3.7.1" />
-    <PackageReference Include="MongoDB.Driver" Version="3.5.0" />
+    <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.10" />
-    <PackageReference Include="Testcontainers.MongoDb" Version="4.8.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.2" />
+    <PackageReference Include="Testcontainers.MongoDb" Version="4.10.0" />
   </ItemGroup>
 </Project>

--- a/src/Hangfire.Mongo.Sample.ASPNetCore/Views/Shared/_Layout.cshtml
+++ b/src/Hangfire.Mongo.Sample.ASPNetCore/Views/Shared/_Layout.cshtml
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>@ViewBag.Title - Mongo storage profider for Hangfire</title>
+    <title>@ViewBag.Title - Mongo storage provider for Hangfire</title>
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.css" />
 
 </head>
@@ -12,7 +12,7 @@
         @RenderBody()
         <hr />
         <footer>
-            <p>&copy; @DateTime.Now.Year - Mongo storage profider for <a href="http://hangfire.io">Hangfire</a></p>
+            <p>&copy; @DateTime.Now.Year - Mongo storage provider for <a href="http://hangfire.io">Hangfire</a></p>
         </footer>
     </div>
 

--- a/src/Hangfire.Mongo.Sample.CosmosDB/Hangfire.Mongo.Sample.CosmosDB.csproj
+++ b/src/Hangfire.Mongo.Sample.CosmosDB/Hangfire.Mongo.Sample.CosmosDB.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Description />
     <Description>MongoDB storage implementation for Hangfire (background job system for ASP.NET applications).</Description>
     <Copyright>Copyright © 2014-2019 Sergey Zwezdin, Martin Lobger, Jonas Gottschau</Copyright>
@@ -23,9 +23,9 @@
     <PackageReference Include="Hangfire.AspNetCore" Version="1.8.22" />
     <PackageReference Include="Hangfire.Core" Version="1.8.22" />
     <PackageReference Include="jquery" Version="3.7.1" />
-    <PackageReference Include="MongoDB.Driver" Version="3.5.0" />
+    <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 </Project>

--- a/src/Hangfire.Mongo.Sample.CosmosDB/Views/Shared/_Layout.cshtml
+++ b/src/Hangfire.Mongo.Sample.CosmosDB/Views/Shared/_Layout.cshtml
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>@ViewBag.Title - Mongo storage profider for Hangfire</title>
+    <title>@ViewBag.Title - Mongo storage provider for Hangfire</title>
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.css" />
 
 </head>
@@ -12,7 +12,7 @@
         @RenderBody()
         <hr />
         <footer>
-            <p>&copy; @DateTime.Now.Year - Mongo storage profider for <a href="http://hangfire.io">Hangfire</a></p>
+            <p>&copy; @DateTime.Now.Year - Mongo storage provider for <a href="http://hangfire.io">Hangfire</a></p>
         </footer>
     </div>
 

--- a/src/Hangfire.Mongo.Sample.NETCore/Hangfire.Mongo.Sample.NETCore.csproj
+++ b/src/Hangfire.Mongo.Sample.NETCore/Hangfire.Mongo.Sample.NETCore.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>Hangfire.Mongo.Sample.NETCore</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Hangfire.Mongo.Sample.NETCore</PackageId>
@@ -19,7 +19,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Hangfire.Core" Version="1.8.22" />
-    <PackageReference Include="MongoDB.Driver" Version="3.5.0" />
-    <PackageReference Include="Testcontainers.MongoDb" Version="4.8.1" />
+    <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
+    <PackageReference Include="Testcontainers.MongoDb" Version="4.10.0" />
   </ItemGroup>
 </Project>

--- a/src/Hangfire.Mongo.Tests/Hangfire.Mongo.Tests.csproj
+++ b/src/Hangfire.Mongo.Tests/Hangfire.Mongo.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <NoWarn>$(NoWarn);CS0618</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>Hangfire.Mongo.Tests</AssemblyName>
@@ -24,10 +24,10 @@
     <ProjectReference Include="../Hangfire.Mongo/Hangfire.Mongo.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="Testcontainers.MongoDb" Version="4.8.1" />
-    <PackageReference Include="Testcontainers.Xunit" Version="4.8.1" />
+    <PackageReference Include="Testcontainers.MongoDb" Version="4.10.0" />
+    <PackageReference Include="Testcontainers.Xunit" Version="4.10.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all" />
     <PackageReference Include="xunit" Version="2.9.3" />
   </ItemGroup>

--- a/src/Hangfire.Mongo.Tests/Migration/Version23MigrationStepFacts.cs
+++ b/src/Hangfire.Mongo.Tests/Migration/Version23MigrationStepFacts.cs
@@ -1,0 +1,346 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Hangfire.Mongo.Migration;
+using Hangfire.Mongo.Migration.Steps.Version23;
+using Hangfire.Mongo.Tests.Utils;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Xunit;
+
+namespace Hangfire.Mongo.Tests.Migration
+{
+    [Collection("Database")]
+    public class Version23MigrationStepFacts
+    {
+        private readonly IMongoDatabase _database;
+        private readonly MongoStorageOptions _storageOptions;
+
+        public Version23MigrationStepFacts(MongoIntegrationTestFixture fixture)
+        {
+            var dbContext = fixture.CreateDbContext();
+            _database = dbContext.Database;
+            _storageOptions = new MongoStorageOptions();
+        }
+
+        #region Step 00 - CreateStateHistoryCollectionMigrationStep
+
+        [Fact]
+        public void ExecuteStep00_CreateStateHistoryCollection_Success()
+        {
+            // ARRANGE
+            var migration = new CreateStateHistoryCollectionMigrationStep();
+            var collectionName = _storageOptions.Prefix + ".stateHistory";
+            
+            // Drop collection if it exists
+            _database.DropCollection(collectionName);
+
+            // ACT
+            var result = migration.Execute(_database, _storageOptions, new MongoMigrationContext());
+
+            // ASSERT
+            Assert.True(result, "Expected migration to be successful, reported 'false'");
+            
+            var filter = new BsonDocument("name", collectionName);
+            var collections = _database.ListCollections(new ListCollectionsOptions { Filter = filter }).ToList();
+            Assert.Single(collections);
+        }
+
+        [Fact]
+        public void ExecuteStep00_CreateStateHistoryCollection_CreatesJobIdIndex()
+        {
+            // ARRANGE
+            var migration = new CreateStateHistoryCollectionMigrationStep();
+            var collectionName = _storageOptions.Prefix + ".stateHistory";
+            
+            // Drop collection if it exists
+            _database.DropCollection(collectionName);
+
+            // ACT
+            var result = migration.Execute(_database, _storageOptions, new MongoMigrationContext());
+
+            // ASSERT
+            Assert.True(result, "Expected migration to be successful, reported 'false'");
+            
+            var collection = _database.GetCollection<BsonDocument>(collectionName);
+            var indexes = collection.Indexes.List().ToList();
+            var jobIdIndex = indexes.FirstOrDefault(i => i["name"].AsString == "IX_JobId");
+            
+            Assert.NotNull(jobIdIndex);
+        }
+
+        [Fact]
+        public void ExecuteStep00_CreateStateHistoryCollection_DoesNotCreateIfExists()
+        {
+            // ARRANGE
+            var migration = new CreateStateHistoryCollectionMigrationStep();
+            var collectionName = _storageOptions.Prefix + ".stateHistory";
+            
+            // Drop and create the collection manually first
+            _database.DropCollection(collectionName);
+            _database.CreateCollection(collectionName);
+
+            // ACT
+            var result = migration.Execute(_database, _storageOptions, new MongoMigrationContext());
+
+            // ASSERT
+            Assert.True(result, "Expected migration to be successful, reported 'false'");
+            
+            // Verify collection still exists and no duplicate was created
+            var filter = new BsonDocument("name", collectionName);
+            var collections = _database.ListCollections(new ListCollectionsOptions { Filter = filter }).ToList();
+            Assert.Single(collections);
+            
+            // Index should NOT exist since we created the collection manually (not through migration)
+            var collection = _database.GetCollection<BsonDocument>(collectionName);
+            var indexes = collection.Indexes.List().ToList();
+            var jobIdIndex = indexes.FirstOrDefault(i => i["name"].AsString == "IX_JobId");
+            Assert.Null(jobIdIndex);
+        }
+
+        #endregion
+
+        #region Step 01 - MigrateStateHistoryToCollectionStep
+
+        [Fact]
+        public void ExecuteStep01_MigrateStateHistory_Success()
+        {
+            // ARRANGE
+            var migration = new MigrateStateHistoryToCollectionStep();
+            var jobGraphCollection = _database.GetCollection<BsonDocument>(_storageOptions.Prefix + ".jobGraph");
+            var stateHistoryCollection = _database.GetCollection<BsonDocument>(_storageOptions.Prefix + ".stateHistory");
+            
+            jobGraphCollection.DeleteMany("{}");
+            stateHistoryCollection.DeleteMany("{}");
+            
+            var jobs = CreateJobDtosWithStateHistory(jobCount: 3, stateHistoryPerJob: 2);
+            jobGraphCollection.InsertMany(jobs);
+
+            // ACT
+            var result = migration.Execute(_database, _storageOptions, new MongoMigrationContext());
+
+            // ASSERT
+            Assert.True(result, "Expected migration to be successful, reported 'false'");
+            
+            var migratedHistory = stateHistoryCollection.Find(new BsonDocument()).ToList();
+            Assert.Equal(6, migratedHistory.Count); // 3 jobs * 2 states each
+            
+            foreach (var historyDoc in migratedHistory)
+            {
+                Assert.True(historyDoc.Contains("JobId"));
+                Assert.True(historyDoc.Contains("State"));
+                Assert.True(historyDoc["State"].AsBsonDocument.Contains("Name"));
+                Assert.True(historyDoc["State"].AsBsonDocument.Contains("CreatedAt"));
+            }
+        }
+
+        [Fact]
+        public void ExecuteStep01_MigrateStateHistory_PreservesJobIdReference()
+        {
+            // ARRANGE
+            var migration = new MigrateStateHistoryToCollectionStep();
+            var jobGraphCollection = _database.GetCollection<BsonDocument>(_storageOptions.Prefix + ".jobGraph");
+            var stateHistoryCollection = _database.GetCollection<BsonDocument>(_storageOptions.Prefix + ".stateHistory");
+            
+            jobGraphCollection.DeleteMany("{}");
+            stateHistoryCollection.DeleteMany("{}");
+            
+            var jobs = CreateJobDtosWithStateHistory(jobCount: 2, stateHistoryPerJob: 3);
+            jobGraphCollection.InsertMany(jobs);
+
+            // ACT
+            var result = migration.Execute(_database, _storageOptions, new MongoMigrationContext());
+
+            // ASSERT
+            Assert.True(result, "Expected migration to be successful, reported 'false'");
+            
+            foreach (var job in jobs)
+            {
+                var jobId = job["_id"].AsObjectId;
+                var historyForJob = stateHistoryCollection.Find(new BsonDocument("JobId", jobId)).ToList();
+                Assert.Equal(3, historyForJob.Count);
+            }
+        }
+
+        [Fact]
+        public void ExecuteStep01_MigrateStateHistory_HandlesEmptyStateHistory()
+        {
+            // ARRANGE
+            var migration = new MigrateStateHistoryToCollectionStep();
+            var jobGraphCollection = _database.GetCollection<BsonDocument>(_storageOptions.Prefix + ".jobGraph");
+            var stateHistoryCollection = _database.GetCollection<BsonDocument>(_storageOptions.Prefix + ".stateHistory");
+            
+            jobGraphCollection.DeleteMany("{}");
+            stateHistoryCollection.DeleteMany("{}");
+            
+            var jobs = CreateJobDtosWithStateHistory(jobCount: 2, stateHistoryPerJob: 0);
+            jobGraphCollection.InsertMany(jobs);
+
+            // ACT
+            var result = migration.Execute(_database, _storageOptions, new MongoMigrationContext());
+
+            // ASSERT
+            Assert.True(result, "Expected migration to be successful, reported 'false'");
+            
+            var migratedHistory = stateHistoryCollection.Find(new BsonDocument()).ToList();
+            Assert.Empty(migratedHistory);
+        }
+
+        [Fact]
+        public void ExecuteStep01_MigrateStateHistory_HandlesNoJobs()
+        {
+            // ARRANGE
+            var migration = new MigrateStateHistoryToCollectionStep();
+            var jobGraphCollection = _database.GetCollection<BsonDocument>(_storageOptions.Prefix + ".jobGraph");
+            var stateHistoryCollection = _database.GetCollection<BsonDocument>(_storageOptions.Prefix + ".stateHistory");
+            
+            jobGraphCollection.DeleteMany("{}");
+            stateHistoryCollection.DeleteMany("{}");
+
+            // ACT
+            var result = migration.Execute(_database, _storageOptions, new MongoMigrationContext());
+
+            // ASSERT
+            Assert.True(result, "Expected migration to be successful, reported 'false'");
+            
+            var migratedHistory = stateHistoryCollection.Find(new BsonDocument()).ToList();
+            Assert.Empty(migratedHistory);
+        }
+
+        #endregion
+
+        #region Step 02 - RemoveStateHistoryFromJobDtoStep
+
+        [Fact]
+        public void ExecuteStep02_RemoveStateHistoryFromJobDto_Success()
+        {
+            // ARRANGE
+            var migration = new RemoveStateHistoryFromJobDtoStep();
+            var jobGraphCollection = _database.GetCollection<BsonDocument>(_storageOptions.Prefix + ".jobGraph");
+            
+            jobGraphCollection.DeleteMany("{}");
+            
+            var jobs = CreateJobDtosWithStateHistory(jobCount: 3, stateHistoryPerJob: 2);
+            jobGraphCollection.InsertMany(jobs);
+
+            // ACT
+            var result = migration.Execute(_database, _storageOptions, new MongoMigrationContext());
+
+            // ASSERT
+            Assert.True(result, "Expected migration to be successful, reported 'false'");
+            
+            var filter = new BsonDocument("_t", new BsonArray { "BaseJobDto", "ExpiringJobDto", "JobDto" });
+            var updatedJobs = jobGraphCollection.Find(filter).ToList();
+            
+            foreach (var job in updatedJobs)
+            {
+                Assert.False(job.Contains("StateHistory"), "StateHistory field should have been removed");
+            }
+        }
+
+        [Fact]
+        public void ExecuteStep02_RemoveStateHistoryFromJobDto_PreservesOtherFields()
+        {
+            // ARRANGE
+            var migration = new RemoveStateHistoryFromJobDtoStep();
+            var jobGraphCollection = _database.GetCollection<BsonDocument>(_storageOptions.Prefix + ".jobGraph");
+            
+            jobGraphCollection.DeleteMany("{}");
+            
+            var jobs = CreateJobDtosWithStateHistory(jobCount: 2, stateHistoryPerJob: 2);
+            jobGraphCollection.InsertMany(jobs);
+
+            // ACT
+            var result = migration.Execute(_database, _storageOptions, new MongoMigrationContext());
+
+            // ASSERT
+            Assert.True(result, "Expected migration to be successful, reported 'false'");
+            
+            var filter = new BsonDocument("_t", new BsonArray { "BaseJobDto", "ExpiringJobDto", "JobDto" });
+            var updatedJobs = jobGraphCollection.Find(filter).ToList();
+            
+            foreach (var job in updatedJobs)
+            {
+                Assert.True(job.Contains("_id"));
+                Assert.True(job.Contains("StateName"));
+                Assert.True(job.Contains("CreatedAt"));
+                Assert.True(job.Contains("InvocationData"));
+            }
+        }
+
+        [Fact]
+        public void ExecuteStep02_RemoveStateHistoryFromJobDto_DoesNotAffectOtherDocumentTypes()
+        {
+            // ARRANGE
+            var migration = new RemoveStateHistoryFromJobDtoStep();
+            var jobGraphCollection = _database.GetCollection<BsonDocument>(_storageOptions.Prefix + ".jobGraph");
+            
+            jobGraphCollection.DeleteMany("{}");
+            
+            // Insert a non-JobDto document with a StateHistory field (shouldn't happen, but let's be safe)
+            var otherDoc = new BsonDocument
+            {
+                ["_id"] = ObjectId.GenerateNewId(),
+                ["_t"] = "SomeOtherDto",
+                ["StateHistory"] = new BsonArray { new BsonDocument("Name", "Test") }
+            };
+            jobGraphCollection.InsertOne(otherDoc);
+
+            // ACT
+            var result = migration.Execute(_database, _storageOptions, new MongoMigrationContext());
+
+            // ASSERT
+            Assert.True(result, "Expected migration to be successful, reported 'false'");
+            
+            var otherDocs = jobGraphCollection.Find(new BsonDocument("_t", "SomeOtherDto")).ToList();
+            Assert.Single(otherDocs);
+            Assert.True(otherDocs[0].Contains("StateHistory"), "StateHistory should NOT be removed from non-JobDto documents");
+        }
+
+        #endregion
+
+        #region Helper Methods
+
+        private List<BsonDocument> CreateJobDtosWithStateHistory(int jobCount, int stateHistoryPerJob)
+        {
+            var list = new List<BsonDocument>();
+
+            for (int i = 0; i < jobCount; i++)
+            {
+                var stateHistory = new BsonArray();
+                for (int j = 0; j < stateHistoryPerJob; j++)
+                {
+                    stateHistory.Add(new BsonDocument
+                    {
+                        ["Name"] = $"State{j}",
+                        ["Reason"] = $"Reason for state {j}",
+                        ["CreatedAt"] = DateTime.UtcNow.AddHours(-j),
+                        ["Data"] = new BsonDocument
+                        {
+                            ["Key1"] = "Value1",
+                            ["Key2"] = "Value2"
+                        }
+                    });
+                }
+
+                var jobDto = new BsonDocument
+                {
+                    ["_id"] = ObjectId.GenerateNewId(),
+                    ["_t"] = new BsonArray { "BaseJobDto", "ExpiringJobDto", "JobDto" },
+                    ["StateName"] = "Enqueued",
+                    ["InvocationData"] = "{}",
+                    ["Arguments"] = "[]",
+                    ["CreatedAt"] = DateTime.UtcNow,
+                    ["StateHistory"] = stateHistory,
+                    ["Parameters"] = new BsonDocument()
+                };
+                
+                list.Add(jobDto);
+            }
+
+            return list;
+        }
+
+        #endregion
+    }
+}

--- a/src/Hangfire.Mongo.Tests/Utils/MongoDbFixture.cs
+++ b/src/Hangfire.Mongo.Tests/Utils/MongoDbFixture.cs
@@ -13,10 +13,12 @@ namespace Hangfire.Mongo.Tests.Utils;
 public sealed class MongoIntegrationTestFixture(IMessageSink messageSink) : ContainerFixture<MongoDbBuilder, MongoDbContainer>(messageSink)
 {
     private const string DefaultDatabaseName = @"Hangfire-Mongo-Tests";
-
-    protected override MongoDbBuilder Configure(MongoDbBuilder builder)
+    
+    protected override MongoDbBuilder Configure()
     {
-        return builder.WithImage("mongo:7.0").WithReplicaSet();
+        return new MongoDbBuilder()
+            .WithImage("mongo:7.0")
+            .WithReplicaSet();
     }
 
     public MongoStorage CreateStorage(string databaseName = null)

--- a/src/Hangfire.Mongo/Database/HangfireDbContext.cs
+++ b/src/Hangfire.Mongo/Database/HangfireDbContext.cs
@@ -57,6 +57,11 @@ namespace Hangfire.Mongo.Database
         public IMongoCollection<BsonDocument> JobGraph => Database.GetCollection<BsonDocument>(_prefix + ".jobGraph");
 
         /// <summary>
+        /// Reference to job history collection
+        /// </summary>
+        public IMongoCollection<BsonDocument> StateHistory => Database.GetCollection<BsonDocument>(_prefix + ".stateHistory");
+        
+        /// <summary>
         /// Reference to collection which contains distributed locks
         /// </summary>
         public IMongoCollection<BsonDocument> DistributedLock => Database

--- a/src/Hangfire.Mongo/Dto/JobDto.cs
+++ b/src/Hangfire.Mongo/Dto/JobDto.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using MongoDB.Bson;
 
 namespace Hangfire.Mongo.Dto
@@ -50,11 +49,6 @@ namespace Hangfire.Mongo.Dto
             }
 
             CreatedAt = doc[nameof(CreatedAt)].ToUniversalTime();
-            StateHistory = doc[nameof(StateHistory)]
-                .AsBsonArray
-                .Select(b => b.AsBsonDocument)
-                .Select(b => new StateDto(b))
-                .ToArray();
         }
 
         public string StateName { get; set; }
@@ -64,9 +58,7 @@ namespace Hangfire.Mongo.Dto
         public string Arguments { get; set; }
 
         public Dictionary<string, string> Parameters { get; set; } = new Dictionary<string, string>();
-
-        public StateDto[] StateHistory { get; set; } = new StateDto[0];
-
+        
         public DateTime CreatedAt { get; set; }
 
         public DateTime? FetchedAt { get; set; }
@@ -87,12 +79,6 @@ namespace Hangfire.Mongo.Dto
                 parameters[p.Key] = p.Value.ToBsonValue();
             }
             doc[nameof(Parameters)] = parameters;
-            var history = new BsonArray();
-            foreach (var h in StateHistory)
-            {
-                history.Add(h.Serialize());
-            }
-            doc[nameof(StateHistory)] = history;
             doc[nameof(CreatedAt)] = CreatedAt.ToUniversalTime();
             doc["_t"].AsBsonArray.Add(nameof(JobDto));
         }

--- a/src/Hangfire.Mongo/Dto/JobStateHistoryDto.cs
+++ b/src/Hangfire.Mongo/Dto/JobStateHistoryDto.cs
@@ -1,0 +1,43 @@
+﻿using MongoDB.Bson;
+
+namespace Hangfire.Mongo.Dto
+{
+#pragma warning disable 1591
+    public class JobStateHistoryDto : BaseJobDto
+    {
+        public JobStateHistoryDto()
+        {
+        }
+
+        public JobStateHistoryDto(BsonDocument doc) : base(doc)
+        {
+            if (doc == null)
+            {
+                return;
+            }
+
+            if (doc.TryGetValue(nameof(JobId), out var jobId))
+            {
+                JobId = jobId.AsObjectId;
+            }
+            if (doc.TryGetValue(nameof(State), out var state))
+            {
+                State = new StateDto(state.AsBsonDocument);
+            }
+        }
+        public ObjectId JobId { get; set; }
+        public StateDto State { get; set; }
+        protected override void Serialize(BsonDocument doc)
+        {
+            BsonValue state = BsonNull.Value;
+            if(State != null)
+            {
+                state = State.Serialize();
+            }
+            doc[nameof(JobId)] = JobId;
+            doc[nameof(State)] = state;
+            doc["_t"].AsBsonArray.Add(nameof(JobStateHistoryDto));
+        }
+    }
+#pragma warning restore 1591
+}

--- a/src/Hangfire.Mongo/Dto/StateDto.cs
+++ b/src/Hangfire.Mongo/Dto/StateDto.cs
@@ -30,7 +30,6 @@ namespace Hangfire.Mongo.Dto
                     Data[b.Name] = b.Value.StringOrNull();
                 }
             }
-            
         }
         public string Name { get; set; }
 

--- a/src/Hangfire.Mongo/Hangfire.Mongo.csproj
+++ b/src/Hangfire.Mongo/Hangfire.Mongo.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.1</TargetFramework>
-        <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net472;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net48;netstandard2.1</TargetFrameworks>
         <NoWarn>$(NoWarn);CS0618;</NoWarn>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -12,10 +12,11 @@
         <owners>Jonas Gottschau</owners>
         <Description>MongoDB storage implementation for Hangfire (background job system for ASP.NET applications).</Description>
         <PackageTags>Hangfire AspNet OWIN MongoDB CosmosDB DocumentDb Azure AWS Atlas Long-Running Background Fire-And-Forget Delayed Recurring Tasks Jobs Scheduler Threading Queues</PackageTags>
-        <PackageReleaseNotes>1.12.2
-            - Update to Hangfire.Core 1.8.22
-            - Fixes IsMasterUtcDateTimeStrategy for cosmosdb is unix timestamp. (#436)
-            - Simplify tests (by @0xced)
+        <PackageReleaseNotes>1.13.0
+            - BREAKING: Remove StateHistory from JobDto and move to separate collection for improved performance and scalability
+            - BREAKING: Drop net472 target framework, now targeting netstandard2.1 and net48
+            - Add migration lock heartbeat timer to prevent timeout during long-running migrations
+            - Update to MongoDB.Driver 3.6.0
         </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <!--<PackageLicenseUrl>https://raw.githubusercontent.com/sergun/Hangfire.Mongo/master/LICENSE</PackageLicenseUrl>-->
@@ -28,7 +29,7 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Hangfire.Core" Version="1.8.22" />
-        <PackageReference Include="MongoDB.Driver" Version="3.5.0" />
+        <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     </ItemGroup>
     <ItemGroup>
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">

--- a/src/Hangfire.Mongo/Migration/MongoSchemaExtensions.cs
+++ b/src/Hangfire.Mongo/Migration/MongoSchemaExtensions.cs
@@ -19,8 +19,8 @@ namespace Hangfire.Mongo.Migration
             switch (schema)
             {
                 case MongoSchema.None:
-                    return new[]
-                    {
+                    return
+                    [
                         "_identifiers", // A bug prevented the use of prefix
                         prefix + ".aggregatedcounter",
                         prefix + ".counter",
@@ -32,12 +32,12 @@ namespace Hangfire.Mongo.Migration
                         prefix + ".locks",
                         prefix + ".server",
                         prefix + ".set",
-                        prefix + ".state",
-                    };
+                        prefix + ".state"
+                    ];
 
                 case MongoSchema.Version04:
-                    return new[]
-                    {
+                    return
+                    [
                         "_identifiers", // A bug prevented the use of prefix
                         prefix + ".aggregatedcounter",
                         prefix + ".counter",
@@ -50,12 +50,12 @@ namespace Hangfire.Mongo.Migration
                         prefix + ".schema",
                         prefix + ".server",
                         prefix + ".set",
-                        prefix + ".state",
-                    };
+                        prefix + ".state"
+                    ];
 
                 case MongoSchema.Version05:
-                    return new[]
-                    {
+                    return
+                    [
                         "_identifiers", // A bug prevented the use of prefix
                         prefix + ".aggregatedcounter",
                         prefix + ".counter",
@@ -68,38 +68,38 @@ namespace Hangfire.Mongo.Migration
                         prefix + ".schema",
                         prefix + ".server",
                         prefix + ".set",
-                        prefix + ".state",
-                    };
+                        prefix + ".state"
+                    ];
 
                 case MongoSchema.Version06:
-                    return new[]
-                    {
+                    return
+                    [
                         prefix + ".job",
                         prefix + ".jobQueue",
                         prefix + ".locks",
                         prefix + ".schema",
                         prefix + ".server",
                         prefix + ".statedata"
-                    };
+                    ];
 
                 case MongoSchema.Version07:
                 case MongoSchema.Version08:
-                    return new[]
-                    {
+                    return
+                    [
                         prefix + ".job",
                         prefix + ".jobQueue",
                         prefix + ".locks",
                         prefix + ".schema",
                         prefix + ".server",
                         prefix + ".stateData"
-                    };
+                    ];
 
                 case MongoSchema.Version09:
                 case MongoSchema.Version10:
                 case MongoSchema.Version11:
                 case MongoSchema.Version12:
-                    return new[]
-                    {
+                    return
+                    [
                         prefix + ".job",
                         prefix + ".jobQueue",
                         prefix + ".locks",
@@ -107,41 +107,51 @@ namespace Hangfire.Mongo.Migration
                         prefix + ".server",
                         prefix + ".signal",
                         prefix + ".stateData"
-                    };
+                    ];
 
                 case MongoSchema.Version13:
                 case MongoSchema.Version14:
-                    return new[]
-                    {
+                    return
+                    [
                         prefix + ".jobGraph",
                         prefix + ".locks",
                         prefix + ".schema",
                         prefix + ".server",
                         prefix + ".signal"
-                    };
+                    ];
                 case MongoSchema.Version15:
                 case MongoSchema.Version16:
-                    return new[]
-                    {
+                    return
+                    [
                         prefix + ".jobGraph",
                         prefix + ".locks",
                         prefix + ".schema",
                         prefix + ".server"
-                    };
+                    ];
                 case MongoSchema.Version17:
                 case MongoSchema.Version18:
                 case MongoSchema.Version19:
                 case MongoSchema.Version20:
                 case MongoSchema.Version21:
                 case MongoSchema.Version22:
-                    return new[]
-                    {
+                    return
+                    [
                         prefix + ".jobGraph",
                         prefix + ".locks",
                         prefix + ".schema",
                         prefix + ".server",
                         prefix + ".notifications"
-                    };
+                    ];
+                case MongoSchema.Version23:
+                    return
+                    [
+                        prefix + ".jobGraph",
+                        prefix + ".locks",
+                        prefix + ".schema",
+                        prefix + ".server",
+                        prefix + ".notifications",
+                        prefix + ".stateHistory"
+                    ];
                 default:
                     throw new ArgumentException($@"Unknown schema: '{schema}'", nameof(schema));
             }

--- a/src/Hangfire.Mongo/Migration/Steps/Version20/00_RemoveJobQueueDto.cs
+++ b/src/Hangfire.Mongo/Migration/Steps/Version20/00_RemoveJobQueueDto.cs
@@ -74,7 +74,7 @@ namespace Hangfire.Mongo.Migration.Steps.Version20
                     ["FetchedAt"] = BsonNull.Value,
                     ["StateName"] = new BsonDocument("$ne", BsonNull.Value)
                 })
-                .Project(new BsonDocument(nameof(JobDto.StateHistory), 1))
+                .Project(new BsonDocument("StateHistory", 1))
                 .ToCursor();
 
             

--- a/src/Hangfire.Mongo/Migration/Steps/Version23/00_CreateStateHistoryCollectionMigrationStep.cs
+++ b/src/Hangfire.Mongo/Migration/Steps/Version23/00_CreateStateHistoryCollectionMigrationStep.cs
@@ -1,0 +1,32 @@
+using MongoDB.Driver;
+
+namespace Hangfire.Mongo.Migration.Steps.Version23
+{
+    internal class CreateStateHistoryCollectionMigrationStep : IMongoMigrationStep
+    {
+        public MongoSchema TargetSchema => MongoSchema.Version23;
+        public long Sequence => 0;
+
+        public bool Execute(IMongoDatabase database, MongoStorageOptions storageOptions, IMongoMigrationContext migrationContext)
+        {
+            var collectionName = storageOptions.Prefix + ".stateHistory";
+            
+            // Check if collection already exists to avoid errors
+            var filter = new MongoDB.Bson.BsonDocument("name", collectionName);
+            var collections = database.ListCollections(new ListCollectionsOptions { Filter = filter });
+
+            if (!collections.Any())
+            {
+                database.CreateCollection(collectionName);
+                
+                // Create index on JobId field for efficient querying
+                var collection = database.GetCollection<MongoDB.Bson.BsonDocument>(collectionName);
+                var indexKeysDefinition = Builders<MongoDB.Bson.BsonDocument>.IndexKeys.Ascending("JobId");
+                var indexOptions = new CreateIndexOptions { Name = "IX_JobId" };
+                collection.Indexes.CreateOne(new CreateIndexModel<MongoDB.Bson.BsonDocument>(indexKeysDefinition, indexOptions));
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Hangfire.Mongo/Migration/Steps/Version23/01_MigrateStateHistoryToCollectionStep.cs
+++ b/src/Hangfire.Mongo/Migration/Steps/Version23/01_MigrateStateHistoryToCollectionStep.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Hangfire.Mongo.Migration.Steps.Version23
+{
+    /// <summary>
+    /// Migrates StateHistory from JobDto documents into the separate stateHistory collection.
+    /// </summary>
+    internal class MigrateStateHistoryToCollectionStep : IMongoMigrationStep
+    {
+        public MongoSchema TargetSchema => MongoSchema.Version23;
+        public long Sequence => 1; // Runs after collection creation (Sequence 0)
+
+        public bool Execute(IMongoDatabase database, MongoStorageOptions storageOptions, IMongoMigrationContext migrationContext)
+        {
+            var jobGraphCollection = database.GetCollection<BsonDocument>(storageOptions.Prefix + ".jobGraph");
+            var stateHistoryCollection = database.GetCollection<BsonDocument>(storageOptions.Prefix + ".stateHistory");
+
+            // Filter for JobDto documents that have StateHistory
+            var filter = Builders<BsonDocument>.Filter.And(
+                Builders<BsonDocument>.Filter.Eq("_t", new BsonArray { "BaseJobDto", "ExpiringJobDto", "JobDto" }),
+                Builders<BsonDocument>.Filter.Exists("StateHistory"),
+                Builders<BsonDocument>.Filter.Ne("StateHistory", new BsonArray())
+            );
+
+            var jobs = jobGraphCollection.Find(filter).ToList();
+
+            if (!jobs.Any())
+            {
+                return true;
+            }
+
+            foreach (var job in jobs)
+            {
+                var historyDocuments = new List<BsonDocument>();
+                var jobId = job["_id"].AsObjectId;
+
+                if (!job.TryGetValue("StateHistory", out var stateHistoryValue) || 
+                    stateHistoryValue.IsBsonNull || 
+                    !stateHistoryValue.IsBsonArray)
+                {
+                    continue;
+                }
+
+                var stateHistory = stateHistoryValue.AsBsonArray;
+
+                foreach (var stateDoc in stateHistory.OfType<BsonDocument>())
+                {
+                    var historyDocument = new BsonDocument
+                    {
+                        ["_id"] = ObjectId.GenerateNewId(),
+                        ["JobId"] = jobId,
+                        ["State"] = stateDoc
+                    };
+
+                    historyDocuments.Add(historyDocument);
+                }
+                if (historyDocuments.Any())
+                {
+                    stateHistoryCollection.InsertMany(historyDocuments);
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Hangfire.Mongo/Migration/Steps/Version23/02_RemoveStateHistoryFromJobDtoStep.cs
+++ b/src/Hangfire.Mongo/Migration/Steps/Version23/02_RemoveStateHistoryFromJobDtoStep.cs
@@ -1,0 +1,33 @@
+﻿using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Hangfire.Mongo.Migration.Steps.Version23
+{
+    /// <summary>
+    /// Removes the StateHistory field from JobDto documents after migration to separate collection.
+    /// 
+    /// Note: Expired jobs and their associated state history records are automatically cleaned up by MongoExpirationManager,
+    /// which deletes both JobGraph entries and their corresponding StateHistory entries when jobs expire.
+    /// This ensures that orphaned state history records do not accumulate over time.
+    /// </summary>
+    internal class RemoveStateHistoryFromJobDtoStep : IMongoMigrationStep
+    {
+        public MongoSchema TargetSchema => MongoSchema.Version23;
+        public long Sequence => 2; // Runs after state history migration (Sequence 1)
+
+        public bool Execute(IMongoDatabase database, MongoStorageOptions storageOptions, IMongoMigrationContext migrationContext)
+        {
+            var jobGraphCollection = database.GetCollection<BsonDocument>(storageOptions.Prefix + ".jobGraph");
+
+            // Filter for JobDto documents
+            var filter = Builders<BsonDocument>.Filter.Eq("_t", new BsonArray { "BaseJobDto", "ExpiringJobDto", "JobDto" });
+
+            // Unset (remove) the StateHistory field
+            var update = Builders<BsonDocument>.Update.Unset("StateHistory");
+
+            jobGraphCollection.UpdateMany(filter, update);
+
+            return true;
+        }
+    }
+}

--- a/src/Hangfire.Mongo/MongoSchema.cs
+++ b/src/Hangfire.Mongo/MongoSchema.cs
@@ -104,7 +104,12 @@ namespace Hangfire.Mongo
         /// <summary>
         /// Schema Version 22
         /// </summary>
-        Version22 = 22
+        Version22 = 22,
+
+        /// <summary>
+        /// Schema Version 23
+        /// </summary>
+        Version23 = 23
     }
 
 }


### PR DESCRIPTION
- BREAKING: Remove StateHistory from JobDto and move to separate collection for improved performance and scalability
- BREAKING: Drop net472 target framework, now targeting netstandard2.1 and net48
- Add migration lock heartbeat timer to prevent timeout during long-running migrations
- Update to MongoDB.Driver 3.6.0