### PR TITLE
Fix #452: Immutable FetchToken for queue acknowledgement CAS

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,20 @@
 
 ## Change log
 
+### Unreleased
+- Fix #452: queue acknowledgement was silently lost when the heartbeat had advanced `FetchedAt`
+  on the server while the client missed the response (network blip, primary stepdown,
+  socket timeout). `RemoveFromQueue` now CAS'es on an immutable `FetchToken` issued at fetch
+  time, so heartbeat mutations cannot invalidate the ack. A stolen-lease ack is logged and
+  ignored rather than silently dropping. Adds `JobStorageFeatures.Transaction.RemoveFromQueue`
+  so Hangfire.Core can bundle state transition and queue ack into one transaction.
+- Adds schema `Version25` with a migration that back-fills `FetchToken = null` on existing
+  JobDto documents.
+- BREAKING: `MongoFactory.CreateFetchedJob`, the `MongoFetchedJob` constructor, and
+  `MongoWriteOnlyTransaction.RemoveFromQueue(ObjectId, DateTime, string)` now require a
+  `fetchToken` (string) instead of / in place of `fetchedAt`. Subclasses overriding these
+  members must update their signatures.
+
 ### 1.14.1
 - Show auth mechanism to make IAM auth verifiable from logs, by @lillapetri (#447)
 

--- a/src/Hangfire.Mongo.Tests/Migration/Version25MigrationStepFacts.cs
+++ b/src/Hangfire.Mongo.Tests/Migration/Version25MigrationStepFacts.cs
@@ -1,0 +1,141 @@
+using System;
+using Hangfire.Mongo.Migration;
+using Hangfire.Mongo.Migration.Steps.Version25;
+using Hangfire.Mongo.Tests.Utils;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Xunit;
+
+namespace Hangfire.Mongo.Tests.Migration
+{
+    [Collection("Database")]
+    public class Version25MigrationStepFacts
+    {
+        private readonly IMongoDatabase _database;
+        private readonly MongoStorageOptions _storageOptions;
+
+        public Version25MigrationStepFacts(MongoIntegrationTestFixture fixture)
+        {
+            var dbContext = fixture.CreateDbContext();
+            _database = dbContext.Database;
+            _storageOptions = new MongoStorageOptions();
+        }
+
+        #region Step 00 - AddFetchTokenFieldToJobDtoStep
+
+        [Fact]
+        public void ExecuteStep00_AddFetchTokenField_Success()
+        {
+            // ARRANGE
+            var migration = new AddFetchTokenFieldToJobDtoStep();
+            var jobGraphCollection = _database.GetCollection<BsonDocument>(_storageOptions.Prefix + ".jobGraph");
+
+            jobGraphCollection.DeleteMany("{}");
+
+            var jobDto = new BsonDocument
+            {
+                ["_id"] = ObjectId.GenerateNewId(),
+                ["_t"] = new BsonArray { "BaseJobDto", "ExpiringJobDto", "JobDto" },
+                ["StateName"] = "Enqueued",
+                ["InvocationData"] = "{}",
+                ["Arguments"] = "[]",
+                ["CreatedAt"] = DateTime.UtcNow,
+                ["Parameters"] = new BsonDocument(),
+                ["StateHistory"] = new BsonArray()
+            };
+            jobGraphCollection.InsertOne(jobDto);
+
+            // ACT
+            var result = migration.Execute(_database, _storageOptions, new MongoMigrationContext());
+
+            // ASSERT
+            Assert.True(result, "Expected migration to be successful");
+
+            var updatedJob = jobGraphCollection.Find(new BsonDocument("_id", jobDto["_id"])).First();
+            Assert.True(updatedJob.Contains("FetchToken"));
+            Assert.Equal(BsonNull.Value, updatedJob["FetchToken"]);
+        }
+
+        [Fact]
+        public void ExecuteStep00_AddFetchTokenField_IsIdempotent()
+        {
+            // ARRANGE
+            var migration = new AddFetchTokenFieldToJobDtoStep();
+            var jobGraphCollection = _database.GetCollection<BsonDocument>(_storageOptions.Prefix + ".jobGraph");
+
+            jobGraphCollection.DeleteMany("{}");
+
+            var existingToken = Guid.NewGuid().ToString("N");
+            var jobDto = new BsonDocument
+            {
+                ["_id"] = ObjectId.GenerateNewId(),
+                ["_t"] = new BsonArray { "BaseJobDto", "ExpiringJobDto", "JobDto" },
+                ["StateName"] = "Processing",
+                ["InvocationData"] = "{}",
+                ["Arguments"] = "[]",
+                ["CreatedAt"] = DateTime.UtcNow,
+                ["Parameters"] = new BsonDocument(),
+                ["StateHistory"] = new BsonArray(),
+                ["FetchToken"] = existingToken
+            };
+            jobGraphCollection.InsertOne(jobDto);
+
+            // ACT
+            var result = migration.Execute(_database, _storageOptions, new MongoMigrationContext());
+
+            // ASSERT
+            Assert.True(result, "Expected migration to be successful");
+
+            // Should preserve existing FetchToken value.
+            var updatedJob = jobGraphCollection.Find(new BsonDocument("_id", jobDto["_id"])).First();
+            Assert.Equal(existingToken, updatedJob["FetchToken"].AsString);
+        }
+
+        [Fact]
+        public void ExecuteStep00_AddFetchTokenField_OnlyUpdatesJobDto()
+        {
+            // ARRANGE
+            var migration = new AddFetchTokenFieldToJobDtoStep();
+            var jobGraphCollection = _database.GetCollection<BsonDocument>(_storageOptions.Prefix + ".jobGraph");
+
+            jobGraphCollection.DeleteMany("{}");
+
+            // Insert a JobDto
+            var jobDto = new BsonDocument
+            {
+                ["_id"] = ObjectId.GenerateNewId(),
+                ["_t"] = new BsonArray { "BaseJobDto", "ExpiringJobDto", "JobDto" },
+                ["StateName"] = "Enqueued",
+                ["InvocationData"] = "{}",
+                ["Arguments"] = "[]",
+                ["CreatedAt"] = DateTime.UtcNow,
+                ["Parameters"] = new BsonDocument(),
+                ["StateHistory"] = new BsonArray()
+            };
+            jobGraphCollection.InsertOne(jobDto);
+
+            // Insert a non-JobDto document
+            var otherDoc = new BsonDocument
+            {
+                ["_id"] = ObjectId.GenerateNewId(),
+                ["_t"] = "SomeOtherDto",
+                ["Name"] = "not-a-job"
+            };
+            jobGraphCollection.InsertOne(otherDoc);
+
+            // ACT
+            var result = migration.Execute(_database, _storageOptions, new MongoMigrationContext());
+
+            // ASSERT
+            Assert.True(result, "Expected migration to be successful");
+
+            var updatedJob = jobGraphCollection.Find(new BsonDocument("_id", jobDto["_id"])).First();
+            Assert.True(updatedJob.Contains("FetchToken"));
+
+            var otherUntouched = jobGraphCollection.Find(new BsonDocument("_id", otherDoc["_id"])).First();
+            Assert.False(otherUntouched.Contains("FetchToken"));
+        }
+
+        #endregion
+    }
+}

--- a/src/Hangfire.Mongo.Tests/MongoFetchedJobFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoFetchedJobFacts.cs
@@ -19,6 +19,7 @@ namespace Hangfire.Mongo.Tests
         private const string Queue = "queue";
         private readonly MongoStorageOptions _mongoStorageOptions = new MongoStorageOptions();
         private readonly DateTime _fetchedAt = DateTime.UtcNow;
+        private readonly string _fetchToken = Guid.NewGuid().ToString("N");
         private readonly HangfireDbContext _dbContext;
 
         public MongoFetchedJobFacts(MongoIntegrationTestFixture fixture)
@@ -31,7 +32,7 @@ namespace Hangfire.Mongo.Tests
         public void Ctor_ThrowsAnException_WhenConnectionIsNull()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new MongoFetchedJob(null, _mongoStorageOptions, _fetchedAt, ObjectId.GenerateNewId(), JobId, Queue));
+                () => new MongoFetchedJob(null, _mongoStorageOptions, _fetchedAt, _fetchToken, ObjectId.GenerateNewId(), JobId, Queue));
 
             Assert.Equal("db", exception.ParamName);
         }
@@ -40,7 +41,7 @@ namespace Hangfire.Mongo.Tests
         public void Ctor_ThrowsAnException_WhenQueueIsNull()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new MongoFetchedJob(_dbContext, _mongoStorageOptions, _fetchedAt, ObjectId.GenerateNewId(), JobId, null));
+                () => new MongoFetchedJob(_dbContext, _mongoStorageOptions, _fetchedAt, _fetchToken, ObjectId.GenerateNewId(), JobId, null));
 
             Assert.Equal("queue", exception.ParamName);
         }
@@ -48,7 +49,7 @@ namespace Hangfire.Mongo.Tests
         [Fact]
         public void Ctor_CorrectlySets_AllInstanceProperties()
         {
-            var fetchedJob = new MongoFetchedJob(_dbContext, _mongoStorageOptions, _fetchedAt, ObjectId.GenerateNewId(), JobId, Queue);
+            var fetchedJob = new MongoFetchedJob(_dbContext, _mongoStorageOptions, _fetchedAt, _fetchToken, ObjectId.GenerateNewId(), JobId, Queue);
 
             Assert.Equal(JobId.ToString(), fetchedJob.JobId);
             Assert.Equal(Queue, fetchedJob.Queue);
@@ -61,7 +62,7 @@ namespace Hangfire.Mongo.Tests
             var queue = "default";
             var jobId = ObjectId.GenerateNewId();
             var id = CreateJobQueueRecord(_dbContext, jobId, queue, _fetchedAt);
-            var processingJob = new MongoFetchedJob(_dbContext, _mongoStorageOptions, _fetchedAt, id, jobId, queue);
+            var processingJob = new MongoFetchedJob(_dbContext, _mongoStorageOptions, _fetchedAt, _fetchToken, id, jobId, queue);
 
             // Act
             processingJob.RemoveFromQueue();
@@ -84,9 +85,10 @@ namespace Hangfire.Mongo.Tests
             CreateJobQueueRecord(_dbContext, ObjectId.GenerateNewId(2), "critical", _fetchedAt);
             CreateJobQueueRecord(_dbContext, ObjectId.GenerateNewId(3), "default", _fetchedAt);
 
-            var fetchedJob = new MongoFetchedJob(_dbContext, _mongoStorageOptions, _fetchedAt, ObjectId.GenerateNewId(), ObjectId.GenerateNewId(999), "default");
+            var fetchedJob = new MongoFetchedJob(_dbContext, _mongoStorageOptions, _fetchedAt, _fetchToken, ObjectId.GenerateNewId(), ObjectId.GenerateNewId(999), "default");
 
-            // Act
+            // Act — CAS on (_id, FetchToken) never matches a random id, so the ack silently logs
+            // a warning and leaves the three unrelated documents intact.
             fetchedJob.RemoveFromQueue();
 
             // Assert
@@ -106,7 +108,7 @@ namespace Hangfire.Mongo.Tests
             var queue = "default";
             var jobId = ObjectId.GenerateNewId();
             var id = CreateJobQueueRecord(_dbContext, jobId, queue, _fetchedAt);
-            var processingJob = new MongoFetchedJob(_dbContext, _mongoStorageOptions, _fetchedAt, id, jobId, queue);
+            var processingJob = new MongoFetchedJob(_dbContext, _mongoStorageOptions, _fetchedAt, _fetchToken, id, jobId, queue);
 
             // Act
             processingJob.Requeue();
@@ -124,7 +126,7 @@ namespace Hangfire.Mongo.Tests
             var queue = "default";
             var jobId = ObjectId.GenerateNewId();
             var id = CreateJobQueueRecord(_dbContext, jobId, queue, _fetchedAt);
-            var processingJob = new MongoFetchedJob(_dbContext, _mongoStorageOptions, _fetchedAt, id, jobId, queue);
+            var processingJob = new MongoFetchedJob(_dbContext, _mongoStorageOptions, _fetchedAt, _fetchToken, id, jobId, queue);
 
             // Act
             processingJob.Dispose();
@@ -145,21 +147,68 @@ namespace Hangfire.Mongo.Tests
             var jobId = ObjectId.GenerateNewId();
             var id = CreateJobQueueRecord(_dbContext, jobId, queue, _fetchedAt, ProcessingState.StateName);
             var initialFetchedAt = DateTime.UtcNow;
-            
+
             // Act
-            var job = new MongoFetchedJob(_dbContext, options, initialFetchedAt, id, jobId, queue);
+            var job = new MongoFetchedJob(_dbContext, options, initialFetchedAt, _fetchToken, id, jobId, queue);
             // job runs for 2s, Heartbeat updates job
             Thread.Sleep(TimeSpan.FromSeconds(2));
             job.Dispose();
-            
+
             // Assert
             Assert.True(job.FetchedAt > initialFetchedAt, "Expected job FetchedAt field to be updated");
         }
 
+        [Fact]
+        public void RemoveFromQueue_LeavesDocumentIntact_WhenLeaseWasStolen()
+        {
+            // Arrange — worker A fetches the job (token = _fetchToken).
+            var queue = "default";
+            var jobId = ObjectId.GenerateNewId();
+            var id = CreateJobQueueRecord(_dbContext, jobId, queue, _fetchedAt);
+            var workerA = new MongoFetchedJob(_dbContext, _mongoStorageOptions, _fetchedAt, _fetchToken, id, jobId, queue);
+
+            // Worker B takes over after invisibility timeout — DB token is replaced.
+            var thiefToken = Guid.NewGuid().ToString("N");
+            _dbContext.JobGraph.UpdateOne(
+                new BsonDocument("_id", id),
+                new BsonDocument("$set", new BsonDocument(nameof(JobDto.FetchToken), thiefToken)));
+
+            // Act — ack is a no-op because the CAS does not match; a warning is logged (not asserted here).
+            workerA.RemoveFromQueue();
+
+            // Assert — new owner's lease is preserved in the document.
+            var doc = _dbContext.JobGraph.Find(new BsonDocument("_id", id)).Single();
+            Assert.Equal(queue, doc[nameof(JobDto.Queue)].AsString);
+            Assert.Equal(thiefToken, doc[nameof(JobDto.FetchToken)].AsString);
+        }
+
+        [Fact]
+        public void TransactionRemoveFromQueue_FetchedJobOverload_ClearsOwnershipFields()
+        {
+            // Arrange — simulate an actively fetched job.
+            var queue = "default";
+            var jobId = ObjectId.GenerateNewId();
+            var id = CreateJobQueueRecord(_dbContext, jobId, queue, _fetchedAt);
+            var fetched = new MongoFetchedJob(_dbContext, _mongoStorageOptions, _fetchedAt, _fetchToken, id, jobId, queue);
+
+            // Act — bundled ack path used by Hangfire.Core when Transaction.RemoveFromQueue feature is advertised.
+            using (var tx = new MongoWriteOnlyTransaction(_dbContext, _mongoStorageOptions))
+            {
+                tx.RemoveFromQueue(fetched);
+                tx.Commit();
+            }
+
+            // Assert — queue, fetched-at and fetch-token are all nulled.
+            var doc = _dbContext.JobGraph.Find(new BsonDocument("_id", id)).Single();
+            Assert.Equal(BsonNull.Value, doc[nameof(JobDto.Queue)]);
+            Assert.Equal(BsonNull.Value, doc[nameof(JobDto.FetchToken)]);
+            Assert.Equal(BsonNull.Value, doc[nameof(JobDto.FetchedAt)]);
+        }
+
         private ObjectId CreateJobQueueRecord(
-            HangfireDbContext connection, 
-            ObjectId jobId, 
-            string queue, 
+            HangfireDbContext connection,
+            ObjectId jobId,
+            string queue,
             DateTime? fetchedAt,
             string stateName = null)
         {
@@ -168,6 +217,7 @@ namespace Hangfire.Mongo.Tests
                 Id = jobId,
                 Queue = queue,
                 FetchedAt = fetchedAt,
+                FetchToken = _fetchToken,
                 StateName = stateName
             };
 

--- a/src/Hangfire.Mongo.Tests/MongoJobQueueFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoJobQueueFacts.cs
@@ -148,6 +148,29 @@ namespace Hangfire.Mongo.Tests
         }
 
         [Fact]
+        public void Dequeue_PopulatesFetchToken_ForLegacyDocumentsWithoutIt()
+        {
+            // Arrange — mimic a document written before the FetchToken fix was deployed.
+            var doc = new JobDto { Queue = "default" }.Serialize();
+            doc.Remove(nameof(JobDto.FetchToken));
+            _hangfireDbContext.JobGraph.InsertOne(doc);
+
+            var fetcher = new MongoJobFetcher(_hangfireDbContext, new MongoStorageOptions(), _jobQueueSemaphoreMock);
+            _jobQueueSemaphoreMock.WaitNonBlock("default").Returns(true);
+
+            // Act
+            var payload = (MongoFetchedJob)fetcher.FetchNextJob(DefaultQueues, CreateTimingOutCancellationToken());
+
+            // Assert — token generated at fetch and persisted on the document.
+            Assert.NotNull(payload);
+            Assert.False(string.IsNullOrEmpty(payload.FetchToken));
+            var persisted = _hangfireDbContext.JobGraph
+                .Find(new BsonDocument("_id", ObjectId.Parse(payload.JobId)))
+                .Single();
+            Assert.Equal(payload.FetchToken, persisted[nameof(JobDto.FetchToken)].AsString);
+        }
+
+        [Fact]
         public void Dequeue_ShouldFetchATimedOutJobs_FromTheSpecifiedQueue()
         {
             // Arrange

--- a/src/Hangfire.Mongo.Tests/MongoRunServerFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoRunServerFacts.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using Hangfire.Mongo.Database;
+using Hangfire.Mongo.Dto;
 using Hangfire.Mongo.Migration.Strategies;
 using Hangfire.Mongo.Migration.Strategies.Backup;
 using Hangfire.Mongo.Tests.Utils;
@@ -124,6 +125,40 @@ namespace Hangfire.Mongo.Tests
             Assert.Equal(parentId1, parentId1Expected);
             Assert.Equal(parentId2, parentId2Expected);
 
+        }
+
+        [Fact]
+        public void Enqueue_SuccessfulJob_ClearsQueueAndFetchTokenViaTransactionalAck()
+        {
+            // ARRANGE
+            var jobGraphCollectionName = _fixture.DbContext.JobGraph.CollectionNamespace.CollectionName;
+            var jobGraph = _fixture.DbContext.Database.GetCollection<BsonDocument>(jobGraphCollectionName);
+
+            // ACT
+            var jobId = BackgroundJob.Enqueue<TestJob>(j => j.SetSignal());
+            var signalled = TestJob.Signal.WaitOne(TimeSpan.FromSeconds(20));
+
+            // The worker commits the terminal state transition and the queue ack in one bulk
+            // (enabled by JobStorageFeatures.Transaction.RemoveFromQueue). Poll briefly to let
+            // the commit land after the job callback returned.
+            BsonDocument persisted = null;
+            var deadline = DateTime.UtcNow.AddSeconds(5);
+            while (DateTime.UtcNow < deadline)
+            {
+                persisted = jobGraph.Find(new BsonDocument("_id", ObjectId.Parse(jobId))).FirstOrDefault();
+                if (persisted != null && persisted[nameof(JobDto.Queue)] == BsonNull.Value)
+                {
+                    break;
+                }
+                Thread.Sleep(50);
+            }
+
+            // ASSERT
+            Assert.True(signalled, "job did not run");
+            Assert.NotNull(persisted);
+            Assert.Equal(BsonNull.Value, persisted[nameof(JobDto.Queue)]);
+            Assert.Equal(BsonNull.Value, persisted[nameof(JobDto.FetchToken)]);
+            Assert.Equal(BsonNull.Value, persisted[nameof(JobDto.FetchedAt)]);
         }
     }
 

--- a/src/Hangfire.Mongo.Tests/MongoStorageFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoStorageFacts.cs
@@ -83,6 +83,14 @@ namespace Hangfire.Mongo.Tests
             Assert.Contains(typeof(MongoExpirationManager), componentTypes);
         }
 
+        [Fact]
+        public void HasFeature_TransactionalAcknowledge_ReturnsTrueForMongoFetchedJob()
+        {
+            var key = JobStorageFeatures.Transaction.RemoveFromQueue(typeof(MongoFetchedJob));
+
+            Assert.True(_storage.HasFeature(key));
+        }
+
     }
 
     public class MongoStorageToStringFacts

--- a/src/Hangfire.Mongo.Tests/MongoWriteOnlyTransactionFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoWriteOnlyTransactionFacts.cs
@@ -270,6 +270,29 @@ namespace Hangfire.Mongo.Tests
         }
 
         [Fact]
+        public void AddToQueue_ClearsStaleFetchedAtAndFetchToken()
+        {
+            // Arrange — simulate a document that still carries ownership fields from a previous lease.
+            var jobId = ObjectId.GenerateNewId();
+            _database.JobGraph.InsertOne(new JobDto
+            {
+                Id = jobId,
+                Queue = "default",
+                FetchedAt = DateTime.UtcNow,
+                FetchToken = Guid.NewGuid().ToString("N")
+            }.Serialize());
+
+            // Act — re-enqueue the job.
+            Commit(x => x.AddToQueue("default", jobId.ToString()));
+
+            // Assert — ownership fields wiped so a stale worker cannot later ack the freshly enqueued doc.
+            var job = new JobDto(_database.JobGraph.Find(new BsonDocument("_id", jobId)).Single());
+            Assert.Equal("default", job.Queue);
+            Assert.Null(job.FetchedAt);
+            Assert.Null(job.FetchToken);
+        }
+
+        [Fact]
         public void IncrementCounter_AddsRecordToCounterTable_WithPositiveValue()
         {
             Commit(x => x.IncrementCounter("my-key"));

--- a/src/Hangfire.Mongo/Dto/JobDto.cs
+++ b/src/Hangfire.Mongo/Dto/JobDto.cs
@@ -27,6 +27,10 @@ namespace Hangfire.Mongo.Dto
             {
                 FetchedAt = fetchedAt.ToNullableLocalTime();
             }
+            if (doc.TryGetValue(nameof(FetchToken), out var fetchToken))
+            {
+                FetchToken = fetchToken.StringOrNull();
+            }
             if (doc.TryGetValue(nameof(StateName), out var stateName))
             {
                 StateName = stateName.StringOrNull();
@@ -73,11 +77,14 @@ namespace Hangfire.Mongo.Dto
 
         public string Queue { get; set; }
 
+        public string FetchToken { get; set; }
+
         protected override void Serialize(BsonDocument doc)
         {
             base.Serialize(doc);
             doc[nameof(Queue)] = Queue.ToBsonValue();
             doc[nameof(FetchedAt)] = FetchedAt;
+            doc[nameof(FetchToken)] = FetchToken.ToBsonValue();
             doc[nameof(StateName)] = StateName.ToBsonValue();
             doc[nameof(InvocationData)] = InvocationData.ToBsonValue();
             doc[nameof(Arguments)] = Arguments.ToBsonValue();

--- a/src/Hangfire.Mongo/Migration/MongoSchemaExtensions.cs
+++ b/src/Hangfire.Mongo/Migration/MongoSchemaExtensions.cs
@@ -153,6 +153,7 @@ namespace Hangfire.Mongo.Migration
                         prefix + ".stateHistory"
                     ];
                 case MongoSchema.Version24:
+                case MongoSchema.Version25:
                     return
                     [
                         prefix + ".jobGraph",

--- a/src/Hangfire.Mongo/Migration/Steps/Version25/00_AddFetchTokenFieldToJobDtoStep.cs
+++ b/src/Hangfire.Mongo/Migration/Steps/Version25/00_AddFetchTokenFieldToJobDtoStep.cs
@@ -1,0 +1,31 @@
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Hangfire.Mongo.Migration.Steps.Version25
+{
+    /// <summary>
+    /// Adds FetchToken field (BsonNull) to all JobDto documents so that pre-upgrade jobs are
+    /// readable by the new RemoveFromQueue CAS. Idempotent — skips documents that already have
+    /// the field.
+    /// </summary>
+    internal class AddFetchTokenFieldToJobDtoStep : IMongoMigrationStep
+    {
+        public MongoSchema TargetSchema => MongoSchema.Version25;
+        public long Sequence => 0;
+
+        public bool Execute(IMongoDatabase database, MongoStorageOptions storageOptions, IMongoMigrationContext migrationContext)
+        {
+            var jobGraphCollection = database.GetCollection<BsonDocument>(storageOptions.Prefix + ".jobGraph");
+
+            var filterWithoutFetchToken = Builders<BsonDocument>.Filter.And(
+                Builders<BsonDocument>.Filter.Eq("_t", new BsonArray { "BaseJobDto", "ExpiringJobDto", "JobDto" }),
+                Builders<BsonDocument>.Filter.Not(Builders<BsonDocument>.Filter.Exists("FetchToken"))
+            );
+
+            var setFetchTokenNull = Builders<BsonDocument>.Update.Set("FetchToken", BsonNull.Value);
+            jobGraphCollection.UpdateMany(filterWithoutFetchToken, setFetchTokenNull);
+
+            return true;
+        }
+    }
+}

--- a/src/Hangfire.Mongo/MongoFactory.cs
+++ b/src/Hangfire.Mongo/MongoFactory.cs
@@ -104,19 +104,21 @@ namespace Hangfire.Mongo
         /// <param name="dbContext"></param>
         /// <param name="storageOptions"></param>
         /// <param name="fetchedAt"></param>
+        /// <param name="fetchToken"></param>
         /// <param name="id"></param>
         /// <param name="jobId"></param>
         /// <param name="queue"></param>
         /// <returns></returns>
         public virtual MongoFetchedJob CreateFetchedJob(
-            HangfireDbContext dbContext, 
+            HangfireDbContext dbContext,
             MongoStorageOptions storageOptions,
             DateTime fetchedAt,
-            ObjectId id, 
+            string fetchToken,
+            ObjectId id,
             ObjectId jobId,
             string queue)
         {
-            return new MongoFetchedJob(dbContext, storageOptions, fetchedAt, id, jobId, queue);
+            return new MongoFetchedJob(dbContext, storageOptions, fetchedAt, fetchToken, id, jobId, queue);
         }
 
         /// <summary>

--- a/src/Hangfire.Mongo/MongoFetchedJob.cs
+++ b/src/Hangfire.Mongo/MongoFetchedJob.cs
@@ -23,6 +23,7 @@ namespace Hangfire.Mongo
         private readonly HangfireDbContext _db;
         private readonly MongoStorageOptions _storageOptions;
         private DateTime _fetchedAt;
+        private readonly string _fetchToken;
         private readonly ObjectId _id;
         private readonly object _syncRoot;
 
@@ -38,6 +39,7 @@ namespace Hangfire.Mongo
         /// <param name="db">Database connection</param>
         /// <param name="storageOptions">storage options</param>
         /// <param name="fetchedAt"></param>
+        /// <param name="fetchToken"></param>
         /// <param name="id">Identifier</param>
         /// <param name="jobId">Job ID</param>
         /// <param name="queue">Queue name</param>
@@ -45,6 +47,7 @@ namespace Hangfire.Mongo
             HangfireDbContext db,
             MongoStorageOptions storageOptions,
             DateTime fetchedAt,
+            string fetchToken,
             ObjectId id,
             ObjectId jobId,
             string queue)
@@ -53,6 +56,7 @@ namespace Hangfire.Mongo
             _syncRoot = new object();
             _storageOptions = storageOptions;
             _fetchedAt = fetchedAt;
+            _fetchToken = fetchToken ?? throw new ArgumentNullException(nameof(fetchToken));
             _id = id;
             JobId = jobId.ToString();
             Queue = queue ?? throw new ArgumentNullException(nameof(queue));
@@ -61,6 +65,11 @@ namespace Hangfire.Mongo
                 StartHeartbeat(storageOptions.SlidingInvisibilityTimeout.Value);
             }
         }
+
+        /// <summary>
+        /// Immutable ownership token issued at fetch
+        /// </summary>
+        public string FetchToken => _fetchToken;
 
         /// <summary>
         /// Timestamp job is fetched
@@ -87,10 +96,41 @@ namespace Hangfire.Mongo
         /// </summary>
         public virtual void RemoveFromQueue()
         {
-            using var t = _storageOptions.Factory.CreateMongoWriteOnlyTransaction(_db, _storageOptions);
-            t.RemoveFromQueue(_id, _fetchedAt, Queue);
-            t.Commit();
-            SetRemoved();
+            lock (_syncRoot)
+            {
+                if (_removedFromQueue || _requeued)
+                {
+                    return;
+                }
+
+                var filter = new BsonDocument
+                {
+                    ["_id"] = _id,
+                    [nameof(JobDto.FetchToken)] = _fetchToken,
+                    [nameof(JobDto.Queue)] = Queue
+                };
+                var update = new BsonDocument
+                {
+                    ["$set"] = new BsonDocument
+                    {
+                        [nameof(JobDto.FetchedAt)] = BsonNull.Value,
+                        [nameof(JobDto.FetchToken)] = BsonNull.Value,
+                        [nameof(JobDto.Queue)] = BsonNull.Value
+                    }
+                };
+                var result = _db.JobGraph.UpdateOne(filter, update);
+                _removedFromQueue = true;
+                if (result.MatchedCount == 0)
+                {
+                    // Ack lost: either this lease was stolen by another worker after our
+                    // invisibility timeout, or the document is already gone. Log and return —
+                    // surfacing this as an exception would push Hangfire.Core's Worker into a
+                    // retry path and, ironically, risk double-delivery.
+                    Logger.Warn(
+                        $"Lease lost for job {_id} (queue='{Queue}'): queue acknowledgement matched 0 documents. " +
+                        "Another worker may have reclaimed this job.");
+                }
+            }
         }
 
         /// <summary>
@@ -106,10 +146,18 @@ namespace Hangfire.Mongo
         /// </summary>
         public virtual void Requeue()
         {
-            using var t = _storageOptions.Factory.CreateMongoWriteOnlyTransaction(_db, _storageOptions);
-            t.Requeue(_id, Queue);
-            t.Commit();
-            _requeued = true;
+            lock (_syncRoot)
+            {
+                if (_removedFromQueue || _requeued)
+                {
+                    return;
+                }
+
+                using var t = _storageOptions.Factory.CreateMongoWriteOnlyTransaction(_db, _storageOptions);
+                t.Requeue(_id, Queue);
+                t.Commit();
+                _requeued = true;
+            }
         }
 
         /// <summary>

--- a/src/Hangfire.Mongo/MongoJobFetcher.cs
+++ b/src/Hangfire.Mongo/MongoJobFetcher.cs
@@ -140,12 +140,17 @@ namespace Hangfire.Mongo
                 fetchedAtQuery
             });
             var fetchedAt = DateTime.UtcNow;
-            var update = new BsonDocument("$set", new BsonDocument(nameof(JobDto.FetchedAt), fetchedAt));
-            
+            var fetchToken = Guid.NewGuid().ToString("N");
+            var update = new BsonDocument("$set", new BsonDocument
+            {
+                [nameof(JobDto.FetchedAt)] = fetchedAt,
+                [nameof(JobDto.FetchToken)] = fetchToken
+            });
+
             var fetchedJobDoc = _dbContext
                 .JobGraph
                 .FindOneAndUpdate(filter, update, Options, cancellationToken);
-            
+
             if (fetchedJobDoc == null)
             {
                 return null;
@@ -156,7 +161,7 @@ namespace Hangfire.Mongo
             {
                 Logger.Trace($"Fetched job {fetchedJob.Id} from '{queue}' Thread[{Thread.CurrentThread.ManagedThreadId}]");
             }
-            return _storageOptions.Factory.CreateFetchedJob(_dbContext, _storageOptions, fetchedAt, fetchedJob.Id, fetchedJob.Id, fetchedJob.Queue);
+            return _storageOptions.Factory.CreateFetchedJob(_dbContext, _storageOptions, fetchedAt, fetchToken, fetchedJob.Id, fetchedJob.Id, fetchedJob.Queue);
         }
     }
 }

--- a/src/Hangfire.Mongo/MongoSchema.cs
+++ b/src/Hangfire.Mongo/MongoSchema.cs
@@ -114,7 +114,12 @@ namespace Hangfire.Mongo
         /// <summary>
         /// Schema Version 24 - Moves StateHistory back to embedded field in JobDto
         /// </summary>
-        Version24 = 24
+        Version24 = 24,
+
+        /// <summary>
+        /// Schema Version 25 - Adds FetchToken field to JobDto for lease CAS ack (fixes #452)
+        /// </summary>
+        Version25 = 25
     }
 
 }

--- a/src/Hangfire.Mongo/MongoStorage.cs
+++ b/src/Hangfire.Mongo/MongoStorage.cs
@@ -54,6 +54,7 @@ namespace Hangfire.Mongo
                 {JobStorageFeatures.Transaction.AcquireDistributedLock, true},
                 {JobStorageFeatures.Transaction.CreateJob, true},
                 {JobStorageFeatures.Transaction.SetJobParameter, true},
+                {JobStorageFeatures.Transaction.RemoveFromQueue(typeof(MongoFetchedJob)), true},
                 {JobStorageFeatures.Monitoring.DeletedStateGraphs, true},
                 {JobStorageFeatures.Monitoring.AwaitingJobs, true}
             });

--- a/src/Hangfire.Mongo/MongoWriteOnlyTransaction.cs
+++ b/src/Hangfire.Mongo/MongoWriteOnlyTransaction.cs
@@ -71,7 +71,7 @@ namespace Hangfire.Mongo
         {
             if (fetchedJob is MongoFetchedJob mongoFetchedJob)
             {
-                RemoveFromQueue(mongoFetchedJob.Id, mongoFetchedJob.FetchedAt, mongoFetchedJob.Queue);
+                RemoveFromQueue(mongoFetchedJob.Id, mongoFetchedJob.FetchToken, mongoFetchedJob.Queue);
                 _removedJobs.Add(mongoFetchedJob);
             }
             else
@@ -86,12 +86,17 @@ namespace Hangfire.Mongo
             updates.Set[nameof(KeyJobDto.ExpireAt)] = DateTime.UtcNow.Add(expireIn);
         }
 
-        public virtual void RemoveFromQueue(ObjectId id, DateTime fetchedAt, string queue)
+        public virtual void RemoveFromQueue(ObjectId id, string fetchToken, string queue)
         {
+            if (fetchToken == null)
+            {
+                throw new ArgumentNullException(nameof(fetchToken));
+            }
+
             var filter = new BsonDocument
             {
                 ["_id"] = id,
-                [nameof(JobDto.FetchedAt)] = fetchedAt,
+                [nameof(JobDto.FetchToken)] = fetchToken,
                 [nameof(JobDto.Queue)] = queue
             };
             var update = new BsonDocument
@@ -99,6 +104,7 @@ namespace Hangfire.Mongo
                 ["$set"] = new BsonDocument
                 {
                     [nameof(JobDto.FetchedAt)] = BsonNull.Value,
+                    [nameof(JobDto.FetchToken)] = BsonNull.Value,
                     [nameof(JobDto.Queue)] = BsonNull.Value
                 }
             };
@@ -110,6 +116,7 @@ namespace Hangfire.Mongo
         {
             var updates = GetOrAddJobUpdates(id.ToString());
             updates.Set[nameof(JobDto.FetchedAt)] = BsonNull.Value;
+            updates.Set[nameof(JobDto.FetchToken)] = BsonNull.Value;
             updates.Set[nameof(JobDto.Queue)] = queue.ToBsonValue();
             JobsAddedToQueue.Add(queue);
         }
@@ -219,6 +226,7 @@ namespace Hangfire.Mongo
             var updates = GetOrAddJobUpdates(jobId);
             updates.Set[nameof(JobDto.Queue)] = queue;
             updates.Set[nameof(JobDto.FetchedAt)] = BsonNull.Value;
+            updates.Set[nameof(JobDto.FetchToken)] = BsonNull.Value;
 
             JobsAddedToQueue.Add(queue);
         }
@@ -485,7 +493,19 @@ namespace Hangfire.Mongo
         {
             try
             {
-                jobGraph.BulkWrite(writeModels, bulkWriteOptions);
+                var result = jobGraph.BulkWrite(writeModels, bulkWriteOptions);
+                var updateOneCount = 0;
+                foreach (var wm in writeModels)
+                {
+                    if (wm is UpdateOneModel<BsonDocument>) updateOneCount++;
+                }
+                if (updateOneCount > 0 && result.MatchedCount < updateOneCount)
+                {
+                    Logger.Warn(
+                        $"Bulk matched {result.MatchedCount} of {updateOneCount} UpdateOne models — " +
+                        "a conditional update (likely a RemoveFromQueue ack) did not match. " +
+                        "Another worker may have reclaimed the job, or the document is gone.");
+                }
             }
             catch (Exception e)
             {


### PR DESCRIPTION
## Summary

Closes #452. Fixes silent queue acknowledgement loss that manifested as jobs stuck showing as Processing / double-delivery after brief MongoDB connectivity hiccups.

**Root cause.** `MongoFetchedJob.RemoveFromQueue()` used the local `_fetchedAt` captured at fetch time as the CAS guard (`{_id, FetchedAt, Queue}`). The heartbeat timer updates `FetchedAt` on the server via `$currentDate` and syncs the local copy *only if `FindOneAndUpdate` returned without an exception*. When the server applied the update but the client missed the response (network blip, primary stepdown, socket read timeout under `retryWrites=false` / retries exhausted), the server-side value advanced while `_fetchedAt` stayed stale. The subsequent ack's CAS matched nothing; `BulkWriteResult.MatchedCount` was never inspected; `SetRemoved()` ran unconditionally; the document stayed in the queue.

**Fix.** Switch the CAS to an immutable `FetchToken` (GUID) issued by `MongoJobFetcher` at fetch time and stored on `JobDto`. Heartbeat still mutates `FetchedAt` (it is the liveness signal), but `FetchToken` never changes while a worker owns the job. On a stolen lease (e.g. a subsequent fetch after `SlidingInvisibilityTimeout`), the ack now matches zero and is logged — not thrown, since throwing would push `Worker.Execute` into a retry and risk double-delivery.

Also advertises `JobStorageFeatures.Transaction.RemoveFromQueue(typeof(MongoFetchedJob))` so Hangfire.Core bundles the terminal state transition and the queue ack into one `IWriteOnlyTransaction.Commit()` instead of two separate round trips.

## Changes

- `Dto/JobDto.cs` — new `FetchToken` property + serialize.
- `MongoJobFetcher.cs` — generates `Guid.NewGuid().ToString(\"N\")` per fetch, persists via `\$set`.
- `MongoFactory.CreateFetchedJob`, `MongoFetchedJob` ctor — accept `fetchToken`.
- `MongoFetchedJob.RemoveFromQueue` — direct `UpdateOne` with CAS on `FetchToken`, `MatchedCount==0` logs a warning and returns. Early-return when already removed / requeued under `_syncRoot`.
- `MongoWriteOnlyTransaction`
  - `RemoveFromQueue(ObjectId, string fetchToken, string queue)` replaces the old `DateTime`-based overload; clears `FetchedAt / FetchToken / Queue` together.
  - `RemoveFromQueue(IFetchedJob)` delegates via `MongoFetchedJob.FetchToken` (used by the bundled ack path).
  - `Requeue` and `AddToQueue` now also clear `FetchToken` so re-enqueued documents cannot be silently acked by a stale owner.
  - `ExecuteCommit` emits a warning when `MatchedCount < UpdateOne count` — defensive signal for the bundled ack path.
- `MongoStorage.Features` — advertises `Transaction.RemoveFromQueue(typeof(MongoFetchedJob))`.
- `MongoSchema.Version25` + `Migration/Steps/Version25/00_AddFetchTokenFieldToJobDtoStep.cs` — idempotent back-fill of `FetchToken=null` on existing `JobDto` documents.
- `ChangeLog.md` — entry under \`### Unreleased\`.

## Breaking changes (listed in ChangeLog)

- `MongoFactory.CreateFetchedJob(HangfireDbContext, MongoStorageOptions, DateTime, ObjectId, ObjectId, string)` → new signature requires `string fetchToken` between `fetchedAt` and `id`.
- `MongoFetchedJob` constructor — same change.
- `MongoWriteOnlyTransaction.RemoveFromQueue(ObjectId, DateTime, string)` → `(ObjectId, string fetchToken, string queue)`.

Subclasses overriding these members must update. I deliberately did not add \`\[Obsolete]\` shims that forward to random tokens — those would silently cause \"lease lost\" on every ack after recompile.

## Empirical verification

Reproduction harness exercising real `HangfireDbContext`, `MongoJobFetcher`, `MongoFetchedJob`, `MongoWriteOnlyTransaction` against MongoDB 8.2 single-node replica set.

| Experiment | Baseline (1.14.1) | After fix |
|---|---|---|
| A — realistic flow, heartbeat interval = 1s | 0/30 silent | 0/30 |
| B — reflection-forced stale `_fetchedAt` | 500/500 silent + 500 re-fetched | 0/500 |
| C — Dispose→Requeue (legitimate requeue path) | 200/200 re-fetch | 200/200 re-fetch |
| D — `failCommand` `blockConnection:true, blockTimeMS:3000`, client `socketTimeoutMS=800`, `retryWrites=false` | 7/10 silent + 7 leftover | 0/10 |

## Test plan

- [x] Full unit-test suite: **316 passed, 0 failed, 1 skipped** (was 307 passed) — +9 new, 0 regressions.
- [x] `MongoRunServerFacts.Enqueue_SuccessfulJob_ClearsQueueAndFetchTokenViaTransactionalAck` verifies end-to-end that the bundled ack path, enabled by the advertised feature, clears `Queue / FetchToken / FetchedAt` on the persisted document.
- [x] `Version25MigrationStepFacts` — Success / IsIdempotent / OnlyUpdatesJobDto.
- [x] `MongoFetchedJobFacts.RemoveFromQueue_LeavesDocumentIntact_WhenLeaseWasStolen` — log-on-miss, other worker's lease preserved.
- [x] `MongoWriteOnlyTransactionFacts.AddToQueue_ClearsStaleFetchedAtAndFetchToken`.
- [x] `MongoJobQueueFacts.Dequeue_PopulatesFetchToken_ForLegacyDocumentsWithoutIt` — rolling-upgrade safe.
- [x] `MongoStorageFacts.HasFeature_TransactionalAcknowledge_ReturnsTrueForMongoFetchedJob`.
- [x] `MongoFetchedJobFacts.TransactionRemoveFromQueue_FetchedJobOverload_ClearsOwnershipFields` — bundled ack unit level.

## Open questions for the maintainer

1. Version bump — patch vs. minor? The change is behaviourally a bug fix, but the public signatures I touched are `virtual` extension points.
2. Subclassed `MongoFetchedJob` via a custom `MongoFactory` currently won't get the advertised feature (feature key is `TransactionalAcknowledge:<TypeName>`). I considered a wildcard override but the existing `Features` dictionary pattern is explicit-entry-only, so I left that alone — consumers with a custom fetched-job type can override `HasFeature` themselves.
3. Not tested: 3-node replica set + real `rs.stepDown()` mid-heartbeat. Conceptually equivalent to the `failCommand` repro (server applied, client threw), but happy to validate if you have a rig.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)