### PR TITLE
Follow-up #453: use ModifiedCount instead of MatchedCount

### DIFF
--- a/src/Hangfire.Mongo/MongoFetchedJob.cs
+++ b/src/Hangfire.Mongo/MongoFetchedJob.cs
@@ -120,14 +120,14 @@ namespace Hangfire.Mongo
                 };
                 var result = _db.JobGraph.UpdateOne(filter, update);
                 _removedFromQueue = true;
-                if (result.MatchedCount == 0)
+                if (result.ModifiedCount == 0)
                 {
                     // Ack lost: either this lease was stolen by another worker after our
                     // invisibility timeout, or the document is already gone. Log and return —
                     // surfacing this as an exception would push Hangfire.Core's Worker into a
                     // retry path and, ironically, risk double-delivery.
                     Logger.Warn(
-                        $"Lease lost for job {_id} (queue='{Queue}'): queue acknowledgement matched 0 documents. " +
+                        $"Lease lost for job {_id} (queue='{Queue}'): queue acknowledgement modified 0 documents. " +
                         "Another worker may have reclaimed this job.");
                 }
             }

--- a/src/Hangfire.Mongo/MongoWriteOnlyTransaction.cs
+++ b/src/Hangfire.Mongo/MongoWriteOnlyTransaction.cs
@@ -499,11 +499,11 @@ namespace Hangfire.Mongo
                 {
                     if (wm is UpdateOneModel<BsonDocument>) updateOneCount++;
                 }
-                if (updateOneCount > 0 && result.MatchedCount < updateOneCount)
+                if (updateOneCount > 0 && result.ModifiedCount < updateOneCount)
                 {
                     Logger.Warn(
-                        $"Bulk matched {result.MatchedCount} of {updateOneCount} UpdateOne models — " +
-                        "a conditional update (likely a RemoveFromQueue ack) did not match. " +
+                        $"Bulk modified {result.ModifiedCount} of {updateOneCount} UpdateOne models — " +
+                        "a conditional update (likely a RemoveFromQueue ack) did not apply. " +
                         "Another worker may have reclaimed the job, or the document is gone.");
                 }
             }


### PR DESCRIPTION
Follow-up on #453. We missed your inline review comments until after the merge — addressing the two `MatchedCount` → `ModifiedCount` notes here as a small separate PR.

## Changes

- `MongoFetchedJob.RemoveFromQueue`: `result.ModifiedCount == 0` for the ack-lost detection.
- `MongoWriteOnlyTransaction.ExecuteCommit`: compare `result.ModifiedCount` against the UpdateOne model count.
- Warning messages updated to say "modified" instead of "matched" for consistency.

Since these CAS updates always change values when the filter matches (they clear non-null fields to null), Matched and Modified are equal in practice. But as you pointed out, when we're counting models, `ModifiedCount` reads more truthfully for "did the write actually apply?".

## Not addressed here

The heartbeat suggestion on `MongoFetchedJob.cs:199` (using `DateTime.UtcNow` via `$set` instead of `$currentDate`) — I wasn't sure if you meant it as part of the separate sliding-window bug you mentioned, or something tied to the ack path. Happy to follow up on that one too once you clarify the scope.

## Test plan

- [x] Full suite still green (no behavioural change in practice — same filter semantics).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)